### PR TITLE
Add option to disable TLS for LDAP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Here are some issues we've run into running Hologram that you might want to be a
 
 * **Sometimes OS X workstations don't like SSH agent.** Some developers have needed to do `ssh-add -K` to add their key to the keychain; some have needed to do this every time they boot; and some just don't require it at all. Your mileage may vary.
 * **If you use an ELB to load-balance between Hologram servers, do not have it terminate the TLS connection.** It's pointless to have your ELB use the SSL certificate compiled into Hologram, when the servers themselves know how to handle it. Let them do their job, and have your ELB just use the TCP protocol.
+* **Your LDAP server might not support TLS** In that case, you'll want to set "insecureldap" to true in the server config file which will configure hologram to connect to the LDAP server without using TLS. Otherwise you might just get a (somewhat cryptic) "connection reset by peer" error.
 
 ## License
 

--- a/server/bin/config.go
+++ b/server/bin/config.go
@@ -19,7 +19,8 @@ type Config struct {
 			DN       string `json:"dn"`
 			Password string `json:"password"`
 		} `json:"bind"`
-		Host string `json:"host"`
+		Host         string `json:"host"`
+		InsecureLDAP bool   `json:"insecureldap"`
 	} `json:"ldap"`
 	AWS struct {
 		Account     string `json:"account"`


### PR DESCRIPTION
Provide a flag to avoid using TLS for LDAP connections if the user
really wants to (not enabled by default)

To enable it we just need to pass -insecureldap as a flag to the server binary or add "insecureldap": true to server.json:
{"ldap": {
  "host": "ldap.host",
  "insecureldap": true,
...