### PR TITLE
Fix protobuf reference paths

### DIFF
--- a/protocol/hologram.pb.go
+++ b/protocol/hologram.pb.go
@@ -43,7 +43,7 @@ It has these top-level messages:
 */
 package protocol
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/protocol/wire.go
+++ b/protocol/wire.go
@@ -22,7 +22,7 @@ import (
 	"hash/crc32"
 	"io"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // Common errors we'll run into.


### PR DESCRIPTION
They were out of sync with the other ones. They're autogenerated files and I didn't bother regenerating them but this seems sufficient to get it compiling again.