### PR TITLE
Add a configurable username attribute (still defaults to 'cn')

### DIFF
--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -19,6 +19,7 @@ type Config struct {
 			DN       string `json:"dn"`
 			Password string `json:"password"`
 		} `json:"bind"`
+		UserAttr     string `json:"userattr"`
 		BaseDN       string `json:"basedn"`
 		Host         string `json:"host"`
 		InsecureLDAP bool   `json:"insecureldap"`

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -107,6 +107,10 @@ func main() {
 	var stats g2s.Statter
 	var statsErr error
 
+	if config.LDAP.UserAttr == "" {
+		config.LDAP.UserAttr = "cn"
+	}
+
 	if config.Stats == "" {
 		log.Debug("No statsd server specified; no metrics will be emitted by this program.")
 		stats = g2s.Noop()
@@ -159,13 +163,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.BaseDN)
+	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN)
 	if err != nil {
 		log.Error("Top-level error in LDAPUserCache layer: %s", err.Error())
 		os.Exit(1)
 	}
 
-	serverHandler := server.New(ldapCache, credentialsService, config.AWS.DefaultRole, stats, ldapServer, config.LDAP.BaseDN)
+	serverHandler := server.New(ldapCache, credentialsService, config.AWS.DefaultRole, stats, ldapServer, config.LDAP.UserAttr, config.LDAP.BaseDN)
 	server, err := remote.NewServer(config.Listen, serverHandler.HandleConnection)
 
 	// Wait for a signal from the OS to shutdown.

--- a/config/server.json
+++ b/config/server.json
@@ -5,6 +5,7 @@
       "dn":       "",
       "password": ""
     },
+    "userattr": "cn",
     "basedn": ""
   },
   "aws": {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -129,7 +129,7 @@ func TestServerStateMachine(t *testing.T) {
 			sshKeys:  []string{},
 			req:      neededModifyRequest,
 		}
-		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "dc=testdn,dc=com")
+		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com")
 		r, w := io.Pipe()
 
 		testConnection := protocol.NewMessageConnection(ReadWriter(r, w))

--- a/server/usercache.go
+++ b/server/usercache.go
@@ -54,10 +54,11 @@ type LDAPImplementation interface {
 ldapUserCache connects to LDAP and pulls user settings from it.
 */
 type ldapUserCache struct {
-	users  map[string]*User
-	server LDAPImplementation
-	stats  g2s.Statter
-	baseDN string
+	users    map[string]*User
+	server   LDAPImplementation
+	stats    g2s.Statter
+	userAttr string
+	baseDN   string
 }
 
 /*
@@ -74,7 +75,7 @@ func (luc *ldapUserCache) Update() error {
 		luc.baseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
 		0, 0, false,
-		filter, []string{"sshPublicKey", "cn"},
+		filter, []string{"sshPublicKey", luc.userAttr},
 		nil,
 	)
 
@@ -84,7 +85,7 @@ func (luc *ldapUserCache) Update() error {
 	}
 
 	for _, entry := range searchResult.Entries {
-		username := entry.GetAttributeValue("cn")
+		username := entry.GetAttributeValue(luc.userAttr)
 		userKeys := []ssh.PublicKey{}
 		for _, eachKey := range entry.GetAttributeValues("sshPublicKey") {
 			sshKeyBytes, _ := base64.StdEncoding.DecodeString(eachKey)
@@ -152,12 +153,13 @@ func (luc *ldapUserCache) Authenticate(username string, challenge []byte, sshSig
 /*
 NewLDAPUserCache returns a properly-configured LDAP cache.
 */
-func NewLDAPUserCache(server LDAPImplementation, stats g2s.Statter, baseDN string) (*ldapUserCache, error) {
+func NewLDAPUserCache(server LDAPImplementation, stats g2s.Statter, userAttr string, baseDN string) (*ldapUserCache, error) {
 	retCache := &ldapUserCache{
-		users:  map[string]*User{},
-		server: server,
-		stats:  stats,
-		baseDN: baseDN,
+		users:    map[string]*User{},
+		server:   server,
+		stats:    stats,
+		userAttr: userAttr,
+		baseDN:   baseDN,
 	}
 
 	updateError := retCache.Update()

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -129,7 +129,7 @@ func TestLDAPUserCache(t *testing.T) {
 			Key:  keyValue,
 			Key2: testPublicKey,
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "dc=testdn,dc=com")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 


### PR DESCRIPTION
This should address #18. Mostly just passing the config field through the code to relevant places. I've tested it locally with `sAMAccountName` against Active Directory. The one piece I haven't tested is the `addSSHKey` logic, because I don't know how to invoke it! Happy to make changes if that ends up not working properly.
