### PR TITLE
Support the authorized_keys public key format in addition to the existing one

### DIFF
--- a/server/usercache.go
+++ b/server/usercache.go
@@ -91,8 +91,11 @@ func (luc *ldapUserCache) Update() error {
 			sshKeyBytes, _ := base64.StdEncoding.DecodeString(eachKey)
 			userSSHKey, err := ssh.ParsePublicKey(sshKeyBytes)
 			if err != nil {
-				log.Errorf("SSH key parsing for %s failed! This key will not be added into LDAP.", username)
-				continue
+				userSSHKey, _, _, _, err = ssh.ParseAuthorizedKey([]byte(eachKey))
+				if err != nil {
+					log.Warning("SSH key parsing for user %s failed (key was '%s')! This key will not be added into LDAP.", username, eachKey)
+					continue
+				}
 			}
 
 			userKeys = append(userKeys, userSSHKey)


### PR DESCRIPTION
Should resolve #13. The fallthrough logic should be safe, since I doubt there's any chance of something getting misinterpreted as the wrong format :smile: 

I'm not a go master, so I don't know if the fallthrough nested `if` is idiomatic. I welcome feedback if there's anything that needs fixing!