### PR TITLE
Removed references to username in AssumeRole

### DIFF
--- a/agent/cli_handler.go
+++ b/agent/cli_handler.go
@@ -70,7 +70,7 @@ func (h *cliHandler) HandleConnection(c protocol.MessageReadWriteCloser) {
 				log.Debug("Handling AssumeRole request.")
 				assumeRole := dr.GetAssumeRole()
 
-				err := h.client.AssumeRole(assumeRole.GetUser(), assumeRole.GetRole())
+				err := h.client.AssumeRole(assumeRole.GetRole())
 
 				var agentResponse protocol.AgentResponse
 				if err == nil {

--- a/agent/cli_handler_test.go
+++ b/agent/cli_handler_test.go
@@ -25,7 +25,7 @@ type dummyClient struct {
 	callCount int
 }
 
-func (c *dummyClient) AssumeRole(user string, role string) error {
+func (c *dummyClient) AssumeRole(role string) error {
 	c.callCount++
 	return nil
 }
@@ -42,12 +42,10 @@ func TestCliHandler(t *testing.T) {
 
 		conn := testConnection(ch.HandleConnection)
 
-		user := "user"
 		role := "role"
 		req := &protocol.Message{
 			AgentRequest: &protocol.AgentRequest{
 				AssumeRole: &protocol.AssumeRole{
-					User: &user,
 					Role: &role,
 				},
 			},

--- a/agent/client_test.go
+++ b/agent/client_test.go
@@ -33,7 +33,7 @@ type dummyCredentialsReceiver struct {
 	creds *sts.Credentials
 }
 
-func (r *dummyCredentialsReceiver) SetCredentials(creds *sts.Credentials, user string, role string) {
+func (r *dummyCredentialsReceiver) SetCredentials(creds *sts.Credentials, role string) {
 	r.creds = creds
 }
 
@@ -58,7 +58,7 @@ func TestAssumeRole(t *testing.T) {
 			server.Close()
 		})
 
-		err = c.AssumeRole("test_user", "test_role")
+		err = c.AssumeRole("test_role")
 
 		So(err, ShouldBeNil)
 		So(credentialsReceiver.creds, ShouldNotBeNil)

--- a/agent/credentials_expiration_manager.go
+++ b/agent/credentials_expiration_manager.go
@@ -31,9 +31,8 @@ func NewCredentialsExpirationManager() *credentialsExpirationManager {
 	return &credentialsExpirationManager{}
 }
 
-func (m *credentialsExpirationManager) SetCredentials(newCreds *sts.Credentials, user string, role string) {
+func (m *credentialsExpirationManager) SetCredentials(newCreds *sts.Credentials, role string) {
 	m.creds = newCreds
-	m.user = user
 	m.role = role
 }
 
@@ -61,7 +60,7 @@ func (m *credentialsExpirationManager) maybeRefreshCredentials() error {
 		if m.role != "" {
 			// and we used AssumeRole to generate the current creds
 			// then use AssumeRole to refresh 'em
-			return m.client.AssumeRole(m.user, m.role)
+			return m.client.AssumeRole(m.role)
 		}
 		// go ahead and refresh our creds, just to be safe
 		return m.client.GetUserCredentials()

--- a/agent/credentials_expiration_manager_test.go
+++ b/agent/credentials_expiration_manager_test.go
@@ -26,7 +26,7 @@ type dummyClient2 struct {
 	getUserCredentialsCount int
 }
 
-func (d *dummyClient2) AssumeRole(user string, role string) error {
+func (d *dummyClient2) AssumeRole(role string) error {
 	d.assumeRoleCount++
 	return nil
 }
@@ -47,7 +47,7 @@ func TestCredentialsExpirationManager(t *testing.T) {
 			creds := sts.Credentials{
 				AccessKeyId: "derp",
 			}
-			credsManager.SetCredentials(&creds, "", "")
+			credsManager.SetCredentials(&creds, "")
 
 			retrievedCreds, err := credsManager.GetCredentials()
 			So(err, ShouldBeNil)
@@ -59,7 +59,7 @@ func TestCredentialsExpirationManager(t *testing.T) {
 				AccessKeyId: "derp",
 				Expiration:  time.Now().Add(-time.Duration(1 * time.Hour)),
 			}
-			credsManager.SetCredentials(&creds, "", "")
+			credsManager.SetCredentials(&creds, "")
 
 			_, err := credsManager.GetCredentials()
 			So(err, ShouldBeNil)
@@ -71,7 +71,7 @@ func TestCredentialsExpirationManager(t *testing.T) {
 				AccessKeyId: "derp",
 				Expiration:  time.Now().Add(-time.Duration(5 * time.Minute)),
 			}
-			credsManager.SetCredentials(&creds, "user", "role")
+			credsManager.SetCredentials(&creds, "role")
 
 			_, err := credsManager.GetCredentials()
 			So(err, ShouldBeNil)

--- a/cmd/hologram/main.go
+++ b/cmd/hologram/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 
 	"github.com/AdRoll/hologram/log"
 	"github.com/AdRoll/hologram/protocol"
@@ -62,14 +61,8 @@ func main() {
 }
 
 func use(role string) error {
-	u, err := user.Current()
-	if err != nil {
-		return err
-	}
-
 	response, err := request(&protocol.AgentRequest{
 		AssumeRole: &protocol.AssumeRole{
-			User: &u.Username,
 			Role: &role,
 		},
 	})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -145,13 +145,11 @@ func TestServerStateMachine(t *testing.T) {
 		})
 
 		Convey("After an AssumeRequest", func() {
-			username := "testuser"
 			role := "testrole"
 
 			msg := &protocol.Message{
 				ServerRequest: &protocol.ServerRequest{
 					AssumeRole: &protocol.AssumeRole{
-						User: &username,
 						Role: &role,
 					},
 				},


### PR DESCRIPTION
username isn't used for that message anymore. I'm leaving it in the
message definition in case there are any potential compatibility issues
with old clients/new servers, etc.

Fixes https://github.com/AdRoll/hologram/issues/32