### PR TITLE
Password fixes

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -6,3 +6,4 @@ github.com/nmcclain/ldap f4e67fa4cd924fbe6f271611514caf5589e6a6e5
 github.com/peterbourgon/g2s ec76db4c1ac16400ac0e17ca9c4840e1d23da5dc
 github.com/goamz/goamz/... 63291cb652bc024bcd52303631afad8f230b8244
 github.com/smartystreets/goconvey/... 1d9daca83fc3cf35d01b9d0ac2debad3453bf178
+github.com/howeyc/gopass 2c70fa70727c953c51695f800f25d6b44abb368e

--- a/cmd/hologram-authorize/main.go
+++ b/cmd/hologram-authorize/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/AdRoll/hologram/protocol"
 	"github.com/AdRoll/hologram/transport/remote"
 	"github.com/mitchellh/go-homedir"
+	"github.com/howeyc/gopass"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -85,7 +86,9 @@ func main() {
 	var (
 		user     string
 		password string
+	 	passwordBytes []byte
 		sshKey   string
+
 	)
 
 	sshKey = getAgentSSHKey()
@@ -108,7 +111,8 @@ func main() {
 	password = os.Getenv("LDAP_PASSWORD")
 	if password == "" {
 		fmt.Printf("LDAP Password: ")
-		fmt.Scanf("%s", &password)
+		passwordBytes = gopass.GetPasswdMasked()
+		password = string(passwordBytes[:len(passwordBytes)])
 	}
 
 	// Hash the password so we don't send it in the clear.


### PR DESCRIPTION
The old LDAP password reading displayed the password in plaintext and used scanf so if you had a space in your password it died before reading the whole thing.

Also, on first pull from git, the artifacts directory isn't created automatically, which causes a non-intuitively error messaged build failure.  Adding an empty artifacts directory prevents that.