### PR TITLE
Improve error messaging in hologram-authorize

### DIFF
--- a/cmd/hologram-authorize/main.go
+++ b/cmd/hologram-authorize/main.go
@@ -1,3 +1,16 @@
+// Copyright 2014 AdRoll, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package main
 
 import (

--- a/cmd/hologram-authorize/main_test.go
+++ b/cmd/hologram-authorize/main_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestAuthorize(t *testing.T) {
+	Convey("loadConfig errors on empty agent.json", t, func() {
+		_, err := loadConfig()
+		So(err, ShouldNotBeNil)
+	})
+}


### PR DESCRIPTION
I had to debug a coworker's system recently with a broken agent.json. The error message that hologram-authorize produced was a nil pointer exception. We can do better than that!

@zylad 