### PR TITLE
Installer support for OS X 10.11 (El Capitan)

### DIFF
--- a/agent/support/darwin/com.adroll.hologram-me.plist
+++ b/agent/support/darwin/com.adroll.hologram-me.plist
@@ -8,7 +8,7 @@
   <false/>
   <key>ProgramArguments</key>
   <array>
-    <string>/usr/bin/hologram-boot</string>
+    <string>/usr/local/bin/hologram-boot</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/agent/support/darwin/com.adroll.hologram.plist
+++ b/agent/support/darwin/com.adroll.hologram.plist
@@ -8,7 +8,7 @@
   <true/>
   <key>ProgramArguments</key>
   <array>
-    <string>/usr/bin/hologram-agent</string>
+    <string>/usr/local/bin/hologram-agent</string>
   </array>
   <key>StandardOutPath</key>
   <string>/var/log/hologram.log</string>

--- a/agent/support/darwin/postinstall.sh
+++ b/agent/support/darwin/postinstall.sh
@@ -2,13 +2,30 @@
 # Remove the previous version of Hologram.
 launchctl unload -w /Library/LaunchDaemons/com.adroll.hologram.plist
 
+# Remove previous (old location) hologram binaries if they exist
+if [ -f "/usr/bin/hologram-boot" ]; then
+  rm /usr/bin/hologram-boot
+fi
+
+if [ -f "/usr/bin/hologram-agent" ]; then
+  rm /usr/bin/hologram-agent
+fi
+
+if [ -f "/usr/bin/hologram-authorize" ]; then
+  rm /usr/bin/hologram-authorize
+fi
+
+if [ -f "/usr/bin/hologram" ]; then
+  rm /usr/bin/hologram
+fi
+
 # Copy our previous config file over the new one
 if [ -f "/etc/hologram/agent.json.save" ]; then
     mv /etc/hologram/agent.json /etc/hologram/agent.json.pkgnew
     mv /etc/hologram/agent.json.save /etc/hologram/agent.json
 fi
 
+# Load the services
 launchctl load -w /Library/LaunchDaemons/com.adroll.hologram-ip.plist
 launchctl load -w /Library/LaunchDaemons/com.adroll.hologram.plist
 launchctl load -w /Library/LaunchAgents/com.adroll.hologram-me.plist
-

--- a/buildscripts/build_osx_pkgs.sh
+++ b/buildscripts/build_osx_pkgs.sh
@@ -9,13 +9,13 @@ if [ "$1" != "--no-compile" ]; then
 fi
 
 mkdir -p /hologram-build/darwin/{root,scripts}
-mkdir -p /hologram-build/darwin/root/usr/bin/
+mkdir -p /hologram-build/darwin/root/usr/local/bin/
 mkdir -p /hologram-build/darwin/root/etc/hologram/
 mkdir -p /hologram-build/darwin/root/Library/LaunchDaemons
 mkdir -p /hologram-build/darwin/scripts
 mkdir -p /hologram-build/darwin/flat/base.pkg/
 
-install -m 0755 ${BIN_DIR}/darwin_amd64/hologram{-agent,,-authorize,-boot} /hologram-build/darwin/root/usr/bin/
+install -m 0755 ${BIN_DIR}/darwin_amd64/hologram{-agent,,-authorize,-boot} /hologram-build/darwin/root/usr/local/bin/
 install -m 0644 ${HOLOGRAM_DIR}/config/agent.json /hologram-build/darwin/root/etc/hologram/agent.json
 install -m 0644 ${HOLOGRAM_DIR}/agent/support/darwin/com.adroll.hologram{-ip,-me,}.plist /hologram-build/darwin/root/Library/LaunchDaemons/
 install -m 0755 ${HOLOGRAM_DIR}/agent/support/darwin/postinstall.sh /hologram-build/darwin/scripts/postinstall


### PR DESCRIPTION
El Capitan introduces [System Integrity Protection](https://en.wikipedia.org/wiki/System_Integrity_Protection) which does not allow writing out to certain "protected" directories. Because of the this the installer throws a warning and does not complete

![screenshot 2015-08-10 16 44 05](https://cloud.githubusercontent.com/assets/125599/9188063/aaf51786-3f8c-11e5-8a0f-5d5e2fd73966.png)

The change is minor though we may want to discuss the best method here. I've globally changed it to write to /usr/local/bin. We could also throw a version condition in here if we want to only install to local on 10.11 and above.
