### PR TITLE
Add persistent LDAP layer

### DIFF
--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -13,20 +13,22 @@
 // limitations under the License.
 package main
 
+type LDAP struct {
+	Bind struct {
+		DN       string `json:"dn"`
+		Password string `json:"password"`
+	} `json:"bind"`
+	UserAttr     string `json:"userattr"`
+	BaseDN       string `json:"basedn"`
+	Host         string `json:"host"`
+	InsecureLDAP bool   `json:"insecureldap"`
+	EnableLDAPRoles bool   `json:"enableldaproles"`
+	RoleAttribute   string `json:"roleattr"`
+	DefaultRoleAttr string `json:"defaultroleattr"`
+}
+
 type Config struct {
-	LDAP struct {
-		Bind struct {
-			DN       string `json:"dn"`
-			Password string `json:"password"`
-		} `json:"bind"`
-		UserAttr        string `json:"userattr"`
-		BaseDN          string `json:"basedn"`
-		Host            string `json:"host"`
-		InsecureLDAP    bool   `json:"insecureldap"`
-		EnableLDAPRoles bool   `json:"enableldaproles"`
-		RoleAttribute   string `json:"roleattr"`
-		DefaultRoleAttr string `json:"defaultroleattr"`
-	} `json:"ldap"`
+	LDAP LDAP `json:"ldap"`
 	AWS struct {
 		Account     string `json:"account"`
 		DefaultRole string `json:"defaultrole"`

--- a/server/persistent_ldap.go
+++ b/server/persistent_ldap.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"github.com/nmcclain/ldap"
+)
+
+type persistentLDAP struct {
+	open func() (LDAPImplementation, error)
+	conn LDAPImplementation
+}
+
+func (pl *persistentLDAP) Refresh() error {
+	conn, err := pl.open()
+	if err != nil {
+		return err
+	}
+
+	pl.conn = conn
+	return nil
+}
+
+func (pl *persistentLDAP) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if conn, err := pl.conn.Search(searchRequest); err != nil && err.(*ldap.Error).ResultCode == ldap.ErrorNetwork {
+		pl.Refresh()
+		return pl.conn.Search(searchRequest)
+	} else {
+		return conn, err
+	}
+}
+
+func (pl *persistentLDAP) Modify(modifyRequest *ldap.ModifyRequest) error {
+  if err := pl.conn.Modify(modifyRequest); err != nil && err.(*ldap.Error).ResultCode == ldap.ErrorNetwork {
+		pl.Refresh()
+		return pl.conn.Modify(modifyRequest)
+	} else {
+		return err
+	}
+}
+
+func NewPersistentLDAP(open func() (LDAPImplementation, error)) (LDAPImplementation, error) {
+	conn, err := open()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &persistentLDAP{
+		open: open,
+		conn: conn,
+	}
+
+	return ret, nil
+}

--- a/server/persistent_ldap_test.go
+++ b/server/persistent_ldap_test.go
@@ -1,0 +1,87 @@
+package server_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/AdRoll/hologram/server"
+	"github.com/nmcclain/ldap"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// A server that fails after every call to Search/Modify!
+type FallibleLDAPServer struct {
+	underlying *StubLDAPServer
+	dead bool
+}
+
+func (fls *FallibleLDAPServer) Search(s *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	if fls.dead {
+		return nil, ldap.NewError(ldap.ErrorNetwork, errors.New("connection died in search"))
+	}
+	fls.dead = true
+	return fls.underlying.Search(s)
+}
+
+func (fls *FallibleLDAPServer) Modify(m *ldap.ModifyRequest) error {
+	if fls.dead {
+		return ldap.NewError(ldap.ErrorNetwork, errors.New("connection died in modify"))
+	}
+	fls.dead = true
+	return fls.underlying.Modify(m)
+}
+
+
+func TestPersistentLDAP(t *testing.T) {
+	connWillFail := false
+
+	s := &StubLDAPServer{
+		Keys: []string{},
+	}
+
+	open := func() (server.LDAPImplementation, error) {
+		if connWillFail {
+			return nil, ldap.NewError(ldap.ErrorNetwork, errors.New("failed reconnect"))
+		}
+		return &FallibleLDAPServer{
+			underlying: s,
+			dead:       false,
+		}, nil
+	}
+
+	ldapServer, err := server.NewPersistentLDAP(open)
+
+	Convey("Given an initially working connection to an LDAP server", t, func() {
+		So(err, ShouldBeNil)
+		So(ldapServer, ShouldNotBeNil)
+
+		Convey("A search should return real results", func() {
+			expected, err := s.Search(nil)
+			So(err, ShouldBeNil)
+			actual, err := ldapServer.Search(nil)
+			So(err,      ShouldBeNil)
+			So(expected, ShouldResemble, actual)
+		})
+
+		Convey("A search after failing should reconnect and seamlessly return real results", func() {
+			expected, err := s.Search(nil)
+			So(err, ShouldBeNil)
+			actual, err := ldapServer.Search(nil)
+			So(err,      ShouldBeNil)
+			So(expected, ShouldResemble, actual)
+		})
+
+		Convey("A search that fails to reconnect should return an error", func() {
+			connWillFail = true
+			res, err := ldapServer.Search(nil)
+			So(res, ShouldBeNil)
+			So(err, ShouldNotBeNil)
+		})
+	})
+
+	Convey("An initially broken connection to an LDAP server should fail fast", t, func() {
+		ldapServer, err = server.NewPersistentLDAP(open)
+		So(err,        ShouldNotBeNil)
+		So(ldapServer, ShouldBeNil)
+	})
+}


### PR DESCRIPTION
Before this, Hologram dialed LDAP once and if that connection died, it
would silently fail. This commit adds a new type that implements the
same interface but pings behind the scenes and reconnects if needed.

Fixes #53.