### PR TITLE
LDAP Based Role Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ You will need to modify the Trusted Entities for each of these roles that you cr
     }
 ```
 
+### LDAP Based Roles
+
+Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`.
+
+An LDAP group attribute will have to be chosen for user roles. By default `businessCategory` is chosen for this role since it is part of the core LDAP schema. The attribute used can be modified by editing the `roleAttribute` key in `config/server.json`. The value of this attribute should be the name of the group's role in AWS.
+
+Users will have to be added to a group giving them access to the default role before they can use Hologram. It is recommended that a group such as `Hologram-Users` be created with attribute `businessCategory` set to the name of the default AWS role.
+
 ## Deployment Suggestions
 At AdRoll we have Hologram deployed in a fault-tolerant setup, with the following:
 

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -40,7 +40,7 @@ func main() {
 	if *debugMode {
 		log.DebugMode(true)
 		log.Debug("Enabling debug mode. Use sparingly.")
-  }
+	}
 
 	// Parse in options from the given config file.
 	log.Debug("Loading configuration from %s", *configFile)

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -40,7 +40,7 @@ func main() {
 	if *debugMode {
 		log.DebugMode(true)
 		log.Debug("Enabling debug mode. Use sparingly.")
-	}
+  }
 
 	// Parse in options from the given config file.
 	log.Debug("Loading configuration from %s", *configFile)

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -23,8 +23,8 @@ type Config struct {
 		BaseDN          string `json:"basedn"`
 		Host            string `json:"host"`
 		InsecureLDAP    bool   `json:"insecureldap"`
-    EnableLDAPRoles bool   `json:"enableldaproles"`
-    RoleAttribute   string `json:"roleattr"`
+		EnableLDAPRoles bool   `json:"enableldaproles"`
+		RoleAttribute   string `json:"roleattr"`
 	} `json:"ldap"`
 	AWS struct {
 		Account     string `json:"account"`

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -19,10 +19,12 @@ type Config struct {
 			DN       string `json:"dn"`
 			Password string `json:"password"`
 		} `json:"bind"`
-		UserAttr     string `json:"userattr"`
-		BaseDN       string `json:"basedn"`
-		Host         string `json:"host"`
-		InsecureLDAP bool   `json:"insecureldap"`
+		UserAttr        string `json:"userattr"`
+		BaseDN          string `json:"basedn"`
+		Host            string `json:"host"`
+		InsecureLDAP    bool   `json:"insecureldap"`
+    EnableLDAPRoles bool   `json:"enableldaproles"`
+    RoleAttribute   string `json:"roleattr"`
 	} `json:"ldap"`
 	AWS struct {
 		Account     string `json:"account"`

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -57,7 +57,7 @@ func main() {
 	if *debugMode {
 		log.DebugMode(true)
 		log.Debug("Enabling debug log output. Use sparingly.")
-  }
+	}
 
 	// Parse in options from the given config file.
 	log.Debug("Loading configuration from %s", *configFile)

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -43,8 +43,8 @@ func main() {
 		ldapBindPassword = flag.String("ldapBindPassword", "", "LDAP password for bind.")
 		statsdHost       = flag.String("stats", "", "Address to send statsd metrics to.")
 		iamAccount       = flag.String("account", "", "AWS Account ID for generating IAM Role ARNs")
-    enableLDAPRoles  = flag.Bool("enableldaproles", false, "Enable role support using LDAP directory.")
-    roleAttribute    = flag.String("roleattr", "businessCategory", "Group attribute to get role from.")
+		enableLDAPRoles  = flag.Bool("enableldaproles", false, "Enable role support using LDAP directory.")
+		roleAttribute    = flag.String("roleattr", "businessCategory", "Group attribute to get role from.")
 		defaultRole      = flag.String("role", "", "AWS role to assume by default.")
 		configFile       = flag.String("conf", "/etc/hologram/server.json", "Config file to load.")
 		debugMode        = flag.Bool("debug", false, "Enable debug mode.")
@@ -106,13 +106,13 @@ func main() {
 		config.AWS.DefaultRole = *defaultRole
 	}
 
-  if *enableLDAPRoles {
-    config.LDAP.EnableLDAPRoles = true;
-  }
+	if *enableLDAPRoles {
+		config.LDAP.EnableLDAPRoles = true;
+	}
 
-  if *roleAttribute != "" {
-    config.LDAP.RoleAttribute = *roleAttribute
-  }
+	if *roleAttribute != "" {
+		config.LDAP.RoleAttribute = *roleAttribute
+	}
 
 	var stats g2s.Statter
 	var statsErr error

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -55,7 +55,7 @@ func main() {
 	if *debugMode {
 		log.DebugMode(true)
 		log.Debug("Enabling debug log output. Use sparingly.")
-	}
+  }
 
 	// Parse in options from the given config file.
 	log.Debug("Loading configuration from %s", *configFile)

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -43,6 +43,8 @@ func main() {
 		ldapBindPassword = flag.String("ldapBindPassword", "", "LDAP password for bind.")
 		statsdHost       = flag.String("stats", "", "Address to send statsd metrics to.")
 		iamAccount       = flag.String("account", "", "AWS Account ID for generating IAM Role ARNs")
+    enableLDAPRoles  = flag.Bool("enableldaproles", false, "Enable role support using LDAP directory.")
+    roleAttribute    = flag.String("roleattr", "businessCategory", "Group attribute to get role from.")
 		defaultRole      = flag.String("role", "", "AWS role to assume by default.")
 		configFile       = flag.String("conf", "/etc/hologram/server.json", "Config file to load.")
 		debugMode        = flag.Bool("debug", false, "Enable debug mode.")
@@ -104,6 +106,14 @@ func main() {
 		config.AWS.DefaultRole = *defaultRole
 	}
 
+  if *enableLDAPRoles {
+    config.LDAP.EnableLDAPRoles = true;
+  }
+
+  if *roleAttribute != "" {
+    config.LDAP.RoleAttribute = *roleAttribute
+  }
+
 	var stats g2s.Statter
 	var statsErr error
 
@@ -163,13 +173,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN)
+	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN, config.LDAP.EnableLDAPRoles, config.LDAP.RoleAttribute)
 	if err != nil {
 		log.Errorf("Top-level error in LDAPUserCache layer: %s", err.Error())
 		os.Exit(1)
 	}
 
-	serverHandler := server.New(ldapCache, credentialsService, config.AWS.DefaultRole, stats, ldapServer, config.LDAP.UserAttr, config.LDAP.BaseDN)
+	serverHandler := server.New(ldapCache, credentialsService, config.AWS.DefaultRole, stats, ldapServer, config.LDAP.UserAttr, config.LDAP.BaseDN, config.LDAP.EnableLDAPRoles)
 	server, err := remote.NewServer(config.Listen, serverHandler.HandleConnection)
 
 	// Wait for a signal from the OS to shutdown.

--- a/cmd/hologram/main.go
+++ b/cmd/hologram/main.go
@@ -34,7 +34,7 @@ func main() {
 	var err error
 
 	if len(args) < 1 {
-    fmt.Println("Usage: hologram <cmd>")
+		fmt.Println("Usage: hologram <cmd>")
 		os.Exit(1)
 	}
 

--- a/cmd/hologram/main.go
+++ b/cmd/hologram/main.go
@@ -34,7 +34,7 @@ func main() {
 	var err error
 
 	if len(args) < 1 {
-		fmt.Println("Usage hologram <cmd>")
+    fmt.Println("Usage: hologram <cmd>")
 		os.Exit(1)
 	}
 

--- a/config/server.json
+++ b/config/server.json
@@ -1,16 +1,18 @@
 {
   "ldap": {
-    "host": "",
+    "host": "ldap.example.com:636",
     "bind": {
-      "dn":       "",
-      "password": ""
+      "dn":       "cn=admin,dc=domain,dc=local",
+      "password": "LDAPServerPa$$word"
     },
     "userattr": "cn",
-    "basedn": ""
+    "basedn": "dc=domain,dc=local",
+    "enableldaproles": false,
+    "roleattr": "businessCategory"
   },
   "aws": {
-    "account":      "",
-    "defaultrole":  ""
+    "account":      "123456789010",
+    "defaultrole":  "default"
   },
   "stats":  "localhost:8125",
   "listen": "0.0.0.0:3100"

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -63,21 +63,28 @@ func (s *directSessionTokenService) Start() error {
 	return nil
 }
 
-func (s *directSessionTokenService) AssumeRole(user *User, role string) (*sts.Credentials, error) {
-	var arn string
+func (s* directSessionTokenService) buildARN(role string) string {
+  var arn string
 
-	if strings.HasPrefix(role, "arn:aws:iam") {
-		arn = role
-	} else if strings.Contains(role, ":role/") {
-		arn = fmt.Sprintf("arn:aws:iam::%s", role)
-	} else {
-		arn = fmt.Sprintf("arn:aws:iam::%s:role/%s", s.iamAccount, role)
-	}
+  if strings.HasPrefix(role, "arn:aws:iam") {
+    arn = role
+  } else if strings.Contains(role, ":role/") {
+    arn = fmt.Sprintf("arn:aws:iam::%s", role)
+  } else {
+    arn = fmt.Sprintf("arn:aws:iam::%s:role/%s", s.iamAccount, role)
+  }
+
+  return arn
+}
+
+func (s *directSessionTokenService) AssumeRole(user *User, role string) (*sts.Credentials, error) {
+  var arn string = s.buildARN(role)
 
 	log.Debug("Checking ARN %s against user %s (with access %s)", arn, user.Username, user.ARNs)
 
 	found := false
 	for _, a := range user.ARNs {
+    a = s.buildARN(a)
 		if arn == a {
 			found = true
 			break

--- a/server/server.go
+++ b/server/server.go
@@ -37,13 +37,14 @@ server is a wrapper for all of the connection and message
 handlers that this server implements.
 */
 type server struct {
-	authenticator Authenticator
-	credentials   CredentialService
-	stats         g2s.Statter
-	DefaultRole   string
-	ldapServer    LDAPImplementation
-	userAttr      string
-	baseDN        string
+	authenticator   Authenticator
+	credentials     CredentialService
+	stats           g2s.Statter
+	DefaultRole     string
+	ldapServer      LDAPImplementation
+	userAttr        string
+	baseDN          string
+  enableLDAPRoles bool
 }
 
 /*
@@ -110,7 +111,7 @@ func (sm *server) HandleServerRequest(m protocol.MessageReadWriteCloser, r *prot
 		}
 
 		if user != nil {
-			creds, err := sm.credentials.AssumeRole(user, role)
+			creds, err := sm.credentials.AssumeRole(user, role, sm.enableLDAPRoles)
 			if err != nil {
 				// error message from Amazon, so forward that on to the client
 				errStr := err.Error()
@@ -136,7 +137,7 @@ func (sm *server) HandleServerRequest(m protocol.MessageReadWriteCloser, r *prot
 		}
 
 		if user != nil {
-			creds, err := sm.credentials.AssumeRole(user, sm.DefaultRole)
+			creds, err := sm.credentials.AssumeRole(user, sm.DefaultRole, sm.enableLDAPRoles)
 			if err != nil {
 				log.Errorf("Error trying to handle GetUserCredentials: %s", err.Error())
 				m.Close()
@@ -281,14 +282,15 @@ func makeCredsResponse(creds *sts.Credentials) *protocol.Message {
 New returns a server that can be used as a handler for a
 MessageConnection loop.
 */
-func New(a Authenticator, c CredentialService, r string, s g2s.Statter, l LDAPImplementation, u string, b string) *server {
+func New(a Authenticator, c CredentialService, d string, s g2s.Statter, l LDAPImplementation, u string, b string, e bool) *server {
 	return &server{
-		credentials:   c,
-		authenticator: a,
-		stats:         s,
-		DefaultRole:   r,
-		ldapServer:    l,
-		userAttr:      u,
-		baseDN:        b,
+		credentials:     c,
+		authenticator:   a,
+		stats:           s,
+		DefaultRole:     d,
+		ldapServer:      l,
+		userAttr:        u,
+		baseDN:          b,
+    enableLDAPRoles: e,
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -44,7 +44,7 @@ type server struct {
 	ldapServer      LDAPImplementation
 	userAttr        string
 	baseDN          string
-  enableLDAPRoles bool
+	enableLDAPRoles bool
 }
 
 /*

--- a/server/server.go
+++ b/server/server.go
@@ -291,6 +291,6 @@ func New(a Authenticator, c CredentialService, d string, s g2s.Statter, l LDAPIm
 		ldapServer:      l,
 		userAttr:        u,
 		baseDN:          b,
-    enableLDAPRoles: e,
+		enableLDAPRoles: e,
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -70,7 +70,7 @@ func (*dummyCredentials) GetSessionToken(user *server.User) (*sts.Credentials, e
 	}, nil
 }
 
-func (*dummyCredentials) AssumeRole(user *server.User, role string) (*sts.Credentials, error) {
+func (*dummyCredentials) AssumeRole(user *server.User, role string, enableLDAPRoles bool) (*sts.Credentials, error) {
 	return &sts.Credentials{
 		AccessKeyId:     "access_key",
 		SecretAccessKey: "secret",
@@ -129,7 +129,7 @@ func TestServerStateMachine(t *testing.T) {
 			sshKeys:  []string{},
 			req:      neededModifyRequest,
 		}
-		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com")
+		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com", false)
 		r, w := io.Pipe()
 
 		testConnection := protocol.NewMessageConnection(ReadWriter(r, w))

--- a/server/usercache.go
+++ b/server/usercache.go
@@ -61,8 +61,8 @@ type ldapUserCache struct {
 	stats           g2s.Statter
 	userAttr        string
 	baseDN          string
-  	enableLDAPRoles bool
-  	roleAttribute   string
+	enableLDAPRoles bool
+	roleAttribute   string
 }
 
 /*

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -127,7 +127,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s := &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -202,7 +202,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s = &StubLDAPServer{
 			Keys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 


### PR DESCRIPTION
Implemented LDAP based roles with backwards compatibility for old versions of Hologram through configuration options.

Based directly on pull request #49 by @copumpkin 

@walterking 