### PR TITLE
Added an LDAP user cache refresh period to Hologram

### DIFF
--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -32,4 +32,5 @@ type Config struct {
 	} `json:"aws"`
 	Stats  string `json:"stats"`
 	Listen string `json:"listen"`
+	CacheTimeout int `json:"cachetimeout"`
 }

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -42,7 +42,7 @@ func main() {
 		ldapInsecure     = flag.Bool("insecureLDAP", false, "INSECURE: Don't use TLS for LDAP connection.")
 		ldapBindPassword = flag.String("ldapBindPassword", "", "LDAP password for bind.")
 		statsdHost       = flag.String("statsHost", "", "Address to send statsd metrics to.")
-		iamAccount       = flag.String("iamaccounjt", "", "AWS Account ID for generating IAM Role ARNs")
+		iamAccount       = flag.String("iamaccount", "", "AWS Account ID for generating IAM Role ARNs")
 		enableLDAPRoles  = flag.Bool("ldaproles", false, "Enable role support using LDAP directory.")
 		roleAttribute    = flag.String("roleattribute", "", "Group attribute to get role from.")
 		defaultRole      = flag.String("role", "", "AWS role to assume by default.")

--- a/config/server.json
+++ b/config/server.json
@@ -15,5 +15,6 @@
     "defaultrole":  "default"
   },
   "stats":  "localhost:8125",
-  "listen": "0.0.0.0:3100"
+  "listen": "0.0.0.0:3100",
+  "cachetimeout": 3600
 }


### PR DESCRIPTION
Previously Hologram did not update the LDAP user cache. Added a configuration parameter to choose how often the LDAP user cache updates on the server. This was suggested by @copumpkin in #62.

I also noticed there were some bugs with configuration parameters and I fixed those.

@adriandoolittle