### PR TITLE
Added logical role defaults based on a configurable LDAP attribute

### DIFF
--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -25,12 +25,13 @@ type Config struct {
 		InsecureLDAP    bool   `json:"insecureldap"`
 		EnableLDAPRoles bool   `json:"enableldaproles"`
 		RoleAttribute   string `json:"roleattr"`
+		DefaultRoleAttr string `json:"defaultroleattr"`
 	} `json:"ldap"`
 	AWS struct {
 		Account     string `json:"account"`
 		DefaultRole string `json:"defaultrole"`
 	} `json:"aws"`
-	Stats  string `json:"stats"`
-	Listen string `json:"listen"`
-	CacheTimeout int `json:"cachetimeout"`
+	Stats        string `json:"stats"`
+	Listen       string `json:"listen"`
+	CacheTimeout int    `json:"cachetimeout"`
 }

--- a/config/server.json
+++ b/config/server.json
@@ -9,6 +9,7 @@
     "basedn": "dc=domain,dc=local",
     "enableldaproles": false,
     "roleattr": "businessCategory"
+    "defaultroleattr": "employeeType"
   },
   "aws": {
     "account":      "123456789010",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -59,6 +59,8 @@ func (d *DummyAuthenticator) Authenticate(username string, challenge []byte, sig
 	return d.user, nil
 }
 
+func (d *DummyAuthenticator) Update() error { return nil }
+
 type dummyCredentials struct{}
 
 func (*dummyCredentials) GetSessionToken(user *server.User) (*sts.Credentials, error) {
@@ -129,7 +131,7 @@ func TestServerStateMachine(t *testing.T) {
 			sshKeys:  []string{},
 			req:      neededModifyRequest,
 		}
-		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com", false)
+		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com", false, "")
 		r, w := io.Pipe()
 
 		testConnection := protocol.NewMessageConnection(ReadWriter(r, w))

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -121,13 +121,13 @@ func TestLDAPUserCache(t *testing.T) {
 		keyValue := base64.StdEncoding.EncodeToString(keys[0].Blob)
 
 		// Load in an additional key from the test data.
-		privateKey, _     := ssh.ParsePrivateKey(testKey)
-		testPublicKey     := base64.StdEncoding.EncodeToString(privateKey.PublicKey().Marshal())
+		privateKey, _ := ssh.ParsePrivateKey(testKey)
+		testPublicKey := base64.StdEncoding.EncodeToString(privateKey.PublicKey().Marshal())
 
 		s := &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -196,13 +196,12 @@ func TestLDAPUserCache(t *testing.T) {
 			})
 		})
 
-
 		testAuthorizedKey := string(ssh.MarshalAuthorizedKey(privateKey.PublicKey()))
 
 		s = &StubLDAPServer{
 			Keys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 


### PR DESCRIPTION
Added logical role defaults based on a configurable LDAP attribute on each user. Made Hologram update the LDAP user cache immediately after a failure at assuming the default role in order to give immediate access to new users. Added an error message for when a user does not have Hologram access.

@adriandoolittle