### PR TITLE
Fix for terraform =>0.6.9

### DIFF
--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -105,7 +105,8 @@ These fields are constructed to be obviously wrong and would never be found in t
 production environment.
 */
 func (mds *metadataService) getServices(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "fake-meta-data")
+	w.Header().Set("Server", "EC2ws")
+	fmt.Fprint(w, "meta-data")
 }
 
 func (mds *metadataService) getInstanceID(w http.ResponseWriter, r *http.Request) {

--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -57,6 +57,7 @@ Spawned in the background.
 */
 func (mds *metadataService) listen() {
 	handler := http.NewServeMux()
+	handler.HandleFunc("/latest", mds.getServices)
 	handler.HandleFunc("/latest/meta-data/iam/security-credentials/", mds.enumerateRoles)
 	handler.HandleFunc("/latest/meta-data/iam/security-credentials/hologram-access", mds.getCredentials)
 	handler.HandleFunc("/latest/meta-data/instance-id", mds.getInstanceID)
@@ -103,6 +104,10 @@ Return fake data for programs that depend on data from the metadata service.
 These fields are constructed to be obviously wrong and would never be found in the
 production environment.
 */
+func (mds *metadataService) getServices(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "fake-meta-data")
+}
+
 func (mds *metadataService) getInstanceID(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "i-deadbeef")
 }

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -80,7 +80,7 @@ func TestMetadataService(t *testing.T) {
 
 		Convey("It should return a fake services list.", func() {
 			respBody := string(request(service.Port(), "/latest"))
-			So(respBody, ShouldEqual, "fake-meta-data")
+			So(respBody, ShouldEqual, "meta-data")
 		})
 
 		Convey("It should return a fake instance ID.", func() {

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -78,6 +78,11 @@ func TestMetadataService(t *testing.T) {
 			So(creds.Expiration, ShouldEqual, "2014-10-22T12:21:17Z")
 		})
 
+		Convey("It should return a fake services list.", func() {
+			respBody := string(request(service.Port(), "/latest"))
+			So(respBody, ShouldEqual, "fake-meta-data")
+		})
+
 		Convey("It should return a fake instance ID.", func() {
 			respBody := string(request(service.Port(), "/latest/meta-data/instance-id"))
 			So(respBody, ShouldEqual, "i-deadbeef")


### PR DESCRIPTION
terraform has undergone some changes and it now checks if the metadata service responds before trying to get credentials from it, so we need to implement the /latest handler so it doesn't return a 404.