### PR TITLE
Serverless agent

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -4,6 +4,6 @@ github.com/aybabtme/rgbterm c07e2f009ed2311e9c35bca12ec00b38ccd48283
 github.com/mitchellh/go-homedir 7d2d8c8a4e078ce3c58736ab521a40b37a504c52
 github.com/nmcclain/ldap f4e67fa4cd924fbe6f271611514caf5589e6a6e5
 github.com/peterbourgon/g2s ec76db4c1ac16400ac0e17ca9c4840e1d23da5dc
-github.com/goamz/goamz/... 63291cb652bc024bcd52303631afad8f230b8244
+github.com/aws/aws-sdk-go/... 35c21ff262580265c1d77095d6f712605fd0c3f4
 github.com/smartystreets/goconvey/... 1d9daca83fc3cf35d01b9d0ac2debad3453bf178
 github.com/howeyc/gopass 2c70fa70727c953c51695f800f25d6b44abb368e

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You will need to modify the Trusted Entities for each of these roles that you cr
 
 ### Serverless
 
-The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, define "accessKey" and "secretKey."
+The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, it uses the go sdk [default credentials provider](https://github.com/aws/aws-sdk-go/#configuring-credentials)
 
 The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/${aws:username}").  `hologram me` uses getsessiontoken from sts, which has some [limitations](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html).  With assume role permissions, `hologram use <role>` will assume into any role bypassing those restrictions.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You will need to modify the Trusted Entities for each of these roles that you cr
 ### Serverless
 
 The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, it uses the go sdk [default credentials provider](https://github.com/aws/aws-sdk-go/#configuring-credentials) on the hologram-agent.
-This can be done by adding environment variables to the launch daemon .plist, or setting credentials files for the root user.
+This can be done by adding environment variables to the launch daemon .plist, or set the HOME environment variable in the plist to the directory containing your `.aws` directory.
 
 The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/${aws:username}").  `hologram me` uses getsessiontoken from sts, which has some [limitations](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html).  With assume role permissions, `hologram use <role>` will assume into any role bypassing those restrictions.
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ You will need to modify the Trusted Entities for each of these roles that you cr
     }
 ```
 
+### Serverless
+
+The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, define "accessKey" and "secretKey."
+
+The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/${aws:username}").  `hologram me` uses getsessiontoken from sts, which has some [limitations](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html).  With assume role permissions, `hologram use <role>` will assume into any role bypassing those restrictions.
+
 ### LDAP Based Roles
 
 Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ You will need to modify the Trusted Entities for each of these roles that you cr
 
 ### Serverless
 
-The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, it uses the go sdk [default credentials provider](https://github.com/aws/aws-sdk-go/#configuring-credentials)
+The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, it uses the go sdk [default credentials provider](https://github.com/aws/aws-sdk-go/#configuring-credentials) on the hologram-agent.
+This can be done by adding environment variables to the launch daemon .plist, or setting credentials files for the root user.
 
 The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:user/${aws:username}").  `hologram me` uses getsessiontoken from sts, which has some [limitations](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_control-access_getsessiontoken.html).  With assume role permissions, `hologram use <role>` will assume into any role bypassing those restrictions.
 

--- a/agent/client.go
+++ b/agent/client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/AdRoll/hologram/protocol"
 	"github.com/AdRoll/hologram/transport/remote"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -50,9 +49,14 @@ type accessKeyClient struct {
 	cr          CredentialsReceiver
 }
 
-func AccessKeyClient(accessKey string, secretKey string, cr CredentialsReceiver) *accessKeyClient {
-	sts := sts.New(session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(accessKey, secretKey, "")}))
-	iamconn := iam.New(session.New(&aws.Config{Credentials: credentials.NewStaticCredentials(accessKey, secretKey, "")}))
+func AccessKeyClient(cr CredentialsReceiver) *accessKeyClient {
+	config := aws.Config{}
+	sess, err := session.NewSession(&config)
+	if err != nil {
+		log.Errorf("Unable to load aws sdk session.  Err: %s", err)
+	}
+	sts := sts.New(sess)
+	iamconn := iam.New(sess)
 	iamUser, err := iamconn.GetUser(&iam.GetUserInput{})
 	if err != nil {
 		log.Errorf("Unable to get current user.  Err: %s", err)

--- a/agent/client_test.go
+++ b/agent/client_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/AdRoll/hologram/protocol"
 	"github.com/AdRoll/hologram/transport/remote"
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	. "github.com/smartystreets/goconvey/convey"
 )
 

--- a/agent/credentials_expiration_manager.go
+++ b/agent/credentials_expiration_manager.go
@@ -17,7 +17,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 type credentialsExpirationManager struct {

--- a/agent/credentials_expiration_manager_test.go
+++ b/agent/credentials_expiration_manager_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -39,13 +39,16 @@ func (d *dummyClient2) GetUserCredentials() error {
 func TestCredentialsExpirationManager(t *testing.T) {
 	Convey("TestCredentialsExpirationManager", t, func() {
 		c := &dummyClient2{}
-
+		key := "derp"
+		expiredExpiration := time.Now().Add(-time.Duration(1 * time.Hour))
+		currentExpiration := time.Now()
 		credsManager := NewCredentialsExpirationManager()
 		credsManager.SetClient(c)
 
 		Convey("Valid credentials are returned", func() {
 			creds := sts.Credentials{
-				AccessKeyId: "derp",
+				AccessKeyId: &key,
+				Expiration:  &currentExpiration,
 			}
 			credsManager.SetCredentials(&creds, "")
 
@@ -56,8 +59,8 @@ func TestCredentialsExpirationManager(t *testing.T) {
 
 		Convey("Old credentials are refreshed", func() {
 			creds := sts.Credentials{
-				AccessKeyId: "derp",
-				Expiration:  time.Now().Add(-time.Duration(1 * time.Hour)),
+				AccessKeyId: &key,
+				Expiration:  &expiredExpiration,
 			}
 			credsManager.SetCredentials(&creds, "")
 
@@ -68,8 +71,8 @@ func TestCredentialsExpirationManager(t *testing.T) {
 
 		Convey("Old credentials from AssumeRole are refreshed", func() {
 			creds := sts.Credentials{
-				AccessKeyId: "derp",
-				Expiration:  time.Now().Add(-time.Duration(5 * time.Minute)),
+				AccessKeyId: &key,
+				Expiration:  &expiredExpiration,
 			}
 			credsManager.SetCredentials(&creds, "role")
 

--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 /*
@@ -136,9 +136,9 @@ func (mds *metadataService) getCredentials(w http.ResponseWriter, r *http.Reques
 		Code:            "Success",
 		LastUpdated:     time.Now().UTC().Format(time.RFC3339),
 		Type:            "AWS-HMAC",
-		AccessKeyId:     creds.AccessKeyId,
-		SecretAccessKey: creds.SecretAccessKey,
-		Token:           creds.SessionToken,
+		AccessKeyId:     *creds.AccessKeyId,
+		SecretAccessKey: *creds.SecretAccessKey,
+		Token:           *creds.SessionToken,
 		Expiration:      creds.Expiration.UTC().Format(time.RFC3339),
 	}
 	respBody, err := json.Marshal(resp)

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -42,11 +42,16 @@ func TestMetadataService(t *testing.T) {
 			Port: 0,
 		})
 
+		accessKey := "access_key"
+		secretKey := "secret"
+		token := "token"
+		expiration := time.Date(2014, 10, 22, 12, 21, 17, 00, time.UTC)
 		dummyCreds := &dummyCredentialsSource{creds: &sts.Credentials{
-			AccessKeyId:     "access_key",
-			SessionToken:    "token",
-			SecretAccessKey: "secret",
-			Expiration:      time.Date(2014, 10, 22, 12, 21, 17, 00, time.UTC)}}
+			AccessKeyId:     &accessKey,
+			SecretAccessKey: &secretKey,
+			SessionToken:    &token,
+			Expiration:      &expiration,
+		}}
 
 		service, err := NewMetadataService(testListener, dummyCreds)
 

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -17,5 +17,7 @@ package main
 Config represents the top-level configuration values required by the application.
 */
 type Config struct {
-	Host string `json:"host"`
+	Host      string `json:"host"`
+	AccessKey string `json:"accessKey"`
+	SecretKey string `json:"secretKey"`
 }

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -18,6 +18,4 @@ Config represents the top-level configuration values required by the application
 */
 type Config struct {
 	Host      string `json:"host"`
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
 }

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -29,6 +29,8 @@ import (
 
 var (
 	dialAddress = flag.String("addr", "", "Address to connect to hologram server on.")
+	accessKey   = flag.String("access_key", "", "AWS Account access key for primary user")
+	secretKey   = flag.String("secret_key", "", "AWS Account secret key for primary user")
 	debugMode   = flag.Bool("debug", false, "Enable debug mode.")
 	configFile  = flag.String("conf", "/etc/hologram/agent.json", "Config file to load.")
 	config      Config
@@ -62,10 +64,18 @@ func main() {
 		log.Debug("Using command-line remote address.")
 		config.Host = *dialAddress
 	}
+	if *accessKey != "" {
+		log.Debug("Using command-line access key.")
+		config.AccessKey = *accessKey
+	}
+	if *secretKey != "" {
+		log.Debug("Using command-line secret key.")
+		config.SecretKey = *secretKey
+	}
 
 	// Emit the final config options for debugging if requested.
 	log.Debug("Final config:")
-	log.Debug("Hologram server address: %s", config.Host)
+	log.Debug("Hologram server address: %s, Access key: %s", config.Host, config.AccessKey)
 
 	defer func() {
 		log.Debug("Removing UNIX socket.")
@@ -90,9 +100,16 @@ func main() {
 		os.Exit(1)
 	}
 	mds.Start()
-
+	var client (agent.Client)
 	// Create a hologram client that can be used by other services to talk to the server
-	client := agent.NewClient(config.Host, credsManager)
+	if config.Host != "" {
+		client = agent.NewClient(config.Host, credsManager)
+	} else if config.AccessKey != "" && config.SecretKey != "" {
+		client = agent.AccessKeyClient(config.AccessKey, config.SecretKey, credsManager)
+	} else {
+		log.Errorf("Failed to find either host or both access_key and secret_key inside config file.")
+		os.Exit(1)
+	}
 
 	agentServer := agent.NewCliHandler("/var/run/hologram.sock", client)
 	err = agentServer.Start()

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -28,8 +28,9 @@ import (
 	"github.com/AdRoll/hologram/log"
 	"github.com/AdRoll/hologram/server"
 	"github.com/AdRoll/hologram/transport/remote"
-	"github.com/goamz/goamz/aws"
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/nmcclain/ldap"
 	"github.com/peterbourgon/g2s"
 )
@@ -173,13 +174,7 @@ func main() {
 	}
 
 	// Setup the server state machine that responds to requests.
-	auth, err := aws.GetAuth(os.Getenv("HOLOGRAM_AWSKEY"), os.Getenv("HOLOGRAM_AWSSECRET"), "", time.Now())
-	if err != nil {
-		log.Errorf("Error getting instance credentials: %s", err.Error())
-		os.Exit(1)
-	}
-
-	stsConnection := sts.New(auth, aws.Regions["us-east-1"])
+	stsConnection := sts.New(session.New(&aws.Config{}))
 	credentialsService := server.NewDirectSessionTokenService(config.AWS.Account, stsConnection)
 
 	open := func() (server.LDAPImplementation, error) { return ConnectLDAP(config.LDAP) }

--- a/server/README.md
+++ b/server/README.md
@@ -28,9 +28,3 @@ logging
 -------
 
 All authentications, whether successful or not, can be logged to Amazon SimpleDB to provide an audit trail.
-
-
-MFA tokens
-----------
-
-Hologram Server supports IAM roles that require an MFA token, requesting the token from the Hologram Agent when needed.

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/AdRoll/hologram/log"
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"strings"
 )
 
@@ -38,7 +38,7 @@ STSImplementation exists to enable dependency injection of an
 implementation of STS.
 */
 type STSImplementation interface {
-	AssumeRole(options *sts.AssumeRoleParams) (*sts.AssumeRoleResult, error)
+	AssumeRole(options *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
 }
 
 /*
@@ -99,10 +99,11 @@ func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLD
 		}
 	}
 	log.Debug("User: %s", user.Username)
-	options := &sts.AssumeRoleParams{
-		DurationSeconds: 3600, // the maximum allowed for AssumeRole
-		RoleArn:         arn,
-		RoleSessionName: user.Username,
+	duration := int64(3600)
+	options := &sts.AssumeRoleInput{
+		DurationSeconds: &duration,
+		RoleArn:         &arn,
+		RoleSessionName: &user.Username,
 	}
 
 	r, err := s.sts.AssumeRole(options)
@@ -110,5 +111,5 @@ func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLD
 		log.Debug("Error!! %s", err.Error())
 		return nil, err
 	}
-	return &r.Credentials, nil
+	return r.Credentials, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/AdRoll/hologram/log"
 	"github.com/AdRoll/hologram/protocol"
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/nmcclain/ldap"
 	"github.com/peterbourgon/g2s"
 	"golang.org/x/crypto/ssh"
@@ -289,9 +289,9 @@ func makeCredsResponse(creds *sts.Credentials) *protocol.Message {
 	credsResponse := &protocol.Message{
 		ServerResponse: &protocol.ServerResponse{
 			Credentials: &protocol.STSCredentials{
-				AccessKeyId:     &creds.AccessKeyId,
-				SecretAccessKey: &creds.SecretAccessKey,
-				AccessToken:     &creds.SessionToken,
+				AccessKeyId:     creds.AccessKeyId,
+				SecretAccessKey: creds.SecretAccessKey,
+				AccessToken:     creds.SessionToken,
 				Expiration:      &expiration,
 			},
 		},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/AdRoll/hologram/protocol"
 	"github.com/AdRoll/hologram/server"
-	"github.com/goamz/goamz/sts"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/nmcclain/ldap"
 	"github.com/peterbourgon/g2s"
 	. "github.com/smartystreets/goconvey/convey"
@@ -64,20 +64,28 @@ func (d *DummyAuthenticator) Update() error { return nil }
 type dummyCredentials struct{}
 
 func (*dummyCredentials) GetSessionToken(user *server.User) (*sts.Credentials, error) {
+	accessKey := "access_key"
+	secretKey := "secret"
+	token := "token"
+	expiration := time.Now().Add(5 * time.Minute)
 	return &sts.Credentials{
-		AccessKeyId:     "access_key",
-		SecretAccessKey: "secret",
-		SessionToken:    "token",
-		Expiration:      time.Now().Add(5 * time.Minute),
+		AccessKeyId:     &accessKey,
+		SecretAccessKey: &secretKey,
+		SessionToken:    &token,
+		Expiration:      &expiration,
 	}, nil
 }
 
 func (*dummyCredentials) AssumeRole(user *server.User, role string, enableLDAPRoles bool) (*sts.Credentials, error) {
+	accessKey := "access_key"
+	secretKey := "secret"
+	token := "token"
+	expiration := time.Now().Add(5 * time.Minute)
 	return &sts.Credentials{
-		AccessKeyId:     "access_key",
-		SecretAccessKey: "secret",
-		SessionToken:    "token",
-		Expiration:      time.Now().Add(5 * time.Minute),
+		AccessKeyId:     &accessKey,
+		SecretAccessKey: &secretKey,
+		SessionToken:    &token,
+		Expiration:      &expiration,
 	}, nil
 }
 


### PR DESCRIPTION
adds an option to use long lived user credential in hologram agent, instead of a server.  Switches to aws go sdk due to lack of support for fetching account number.

theres some code duplication, and could be organized a little bit better, but not sure of go standards or understand the server well enough yet to know how its best shared