### PR TITLE
Role aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ You will need to modify the Trusted Entities for each of these roles that you cr
     }
 ```
 
+### Account Aliases
+The config files can set accountAliases, a dictionary from short name to account iam arn, `arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS`.  If you run `hologram use key/rolename`, it will expand it out to the full arn.  This config param is supported on both the server(org wide accounts), or client(individual accounts).
+
+```json
+{
+  "host":"localhost:3100",
+  "accountAliases":{
+    "dev":"arn:aws:iam::123456"
+  }
+}```
+
+With this config, `hologram use dev/service` would be equivalent to `hologram use arn:aws:iam::123456:role/service`
+
 ### Serverless
 
 The hologram agent supports being run without a server, based on long-lived user credentials.  To use, instead of defining host in the config.json file, it uses the go sdk [default credentials provider](https://github.com/aws/aws-sdk-go/#configuring-credentials) on the hologram-agent.

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -18,4 +18,5 @@ Config represents the top-level configuration values required by the application
 */
 type Config struct {
 	Host      string `json:"host"`
+	AccountAliases   map[string]string `json:"accountAliases`
 }

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -95,7 +95,7 @@ func main() {
 	if config.Host != "" {
 		client = agent.NewClient(config.Host, credsManager)
 	} else {
-		client = agent.AccessKeyClient(credsManager)
+		client = agent.AccessKeyClient(credsManager, &config.AccountAliases)
 	}
 	agentServer := agent.NewCliHandler("/var/run/hologram.sock", client)
 	err = agentServer.Start()

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -36,4 +36,5 @@ type Config struct {
 	Stats        string `json:"stats"`
 	Listen       string `json:"listen"`
 	CacheTimeout int    `json:"cachetimeout"`
+	AccountAliases   map[string]string `json:"accountAliases`
 }

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -175,7 +175,7 @@ func main() {
 
 	// Setup the server state machine that responds to requests.
 	stsConnection := sts.New(session.New(&aws.Config{}))
-	credentialsService := server.NewDirectSessionTokenService(config.AWS.Account, stsConnection)
+	credentialsService := server.NewDirectSessionTokenService(config.AWS.Account, stsConnection, &config.AccountAliases)
 
 	open := func() (server.LDAPImplementation, error) { return ConnectLDAP(config.LDAP) }
 	ldapServer, err := server.NewPersistentLDAP(open)

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -31,6 +31,7 @@ results other than that which the CredentialService does itself.
 */
 type CredentialService interface {
 	AssumeRole(user *User, role string, enableLDAPRoles bool) (*sts.Credentials, error)
+	GetSessionToken() (*sts.Credentials, error)
 }
 
 /*
@@ -39,6 +40,7 @@ implementation of STS.
 */
 type STSImplementation interface {
 	AssumeRole(options *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error)
+	GetSessionToken(options *sts.GetSessionTokenInput) (*sts.GetSessionTokenOutput, error)
 }
 
 /*
@@ -47,45 +49,48 @@ directly. It will always return long-lived credentials the developer account
 compiled into the application.
 */
 type directSessionTokenService struct {
-	iamAccount string
-	sts        *sts.STS
+	iamAccount     string
+	sts            *sts.STS
+	accountAliases *map[string]string
 }
 
 /*
 NewDirectSessionTokenService returns a credential service that talks
 to Amazon directly.
 */
-func NewDirectSessionTokenService(iamAccount string, sts *sts.STS) *directSessionTokenService {
-	return &directSessionTokenService{iamAccount: iamAccount, sts: sts}
+func NewDirectSessionTokenService(iamAccount string, sts *sts.STS, accountAliases *map[string]string) *directSessionTokenService {
+	return &directSessionTokenService{iamAccount: iamAccount, sts: sts, accountAliases: accountAliases}
 }
 
 func (s *directSessionTokenService) Start() error {
 	return nil
 }
 
-func (s *directSessionTokenService) buildARN(role string) string {
+func BuildARN(role string, defaultAccount string, accountAliases *map[string]string) string {
 	var arn string
 
-	if strings.HasPrefix(role, "arn:aws:iam") {
+	split := strings.Split(role, "/")
+	if len(split) == 2 && accountAliases != nil && (*accountAliases)[split[0]] != "" {
+		arn = fmt.Sprintf("%s:role/%s", (*accountAliases)[split[0]], split[1])
+	} else if strings.HasPrefix(role, "arn:aws:iam") {
 		arn = role
 	} else if strings.Contains(role, ":role/") {
 		arn = fmt.Sprintf("arn:aws:iam::%s", role)
 	} else {
-		arn = fmt.Sprintf("arn:aws:iam::%s:role/%s", s.iamAccount, role)
+		arn = fmt.Sprintf("arn:aws:iam::%s:role/%s", defaultAccount, role)
 	}
-
 	return arn
 }
 
 func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLDAPRoles bool) (*sts.Credentials, error) {
-	var arn string = s.buildARN(role)
+	var arn string = BuildARN(role, s.iamAccount, s.accountAliases)
 
-	log.Debug("Checking ARN %s against user %s (with access %s)", arn, user.Username, user.ARNs)
+	log.Debug("Checking ARN %s against user %s (with access %s)", arn, user.Username, enableLDAPRoles)
 
 	if enableLDAPRoles {
 		found := false
 		for _, a := range user.ARNs {
-			a = s.buildARN(a)
+			a = BuildARN(a, s.iamAccount, s.accountAliases)
 			if arn == a {
 				found = true
 				break
@@ -112,4 +117,13 @@ func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLD
 		return nil, err
 	}
 	return r.Credentials, nil
+}
+
+func (s *directSessionTokenService) GetSessionToken() (*sts.Credentials, error) {
+	input := sts.GetSessionTokenInput{}
+	response, err := s.sts.GetSessionToken(&input)
+	if err != nil {
+		return nil, err
+	}
+	return response.Credentials, nil
 }

--- a/server/credentials_test.go
+++ b/server/credentials_test.go
@@ -1,0 +1,26 @@
+package server_test
+
+import (
+	"testing"
+	"github.com/AdRoll/hologram/server"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+
+
+func TestBuildARN(t *testing.T) {
+	aliases := map[string]string{
+		"a1": "arn:aws:iam::1234",
+		"a2": "arn:aws:iam::5432",
+	}
+	Convey("A role without an alias should return the default account", t, func() {
+		role := server.BuildARN("rolename", "99999", &aliases)
+		So(role, ShouldResemble, "arn:aws:iam::99999:role/rolename")
+	})
+
+	Convey("A role with an alias should return the alias", t, func() {
+		role := server.BuildARN("a1/rolename", "99999", &aliases)
+		So(role, ShouldResemble, "arn:aws:iam::1234:role/rolename")
+	})
+
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -63,7 +63,7 @@ func (d *DummyAuthenticator) Update() error { return nil }
 
 type dummyCredentials struct{}
 
-func (*dummyCredentials) GetSessionToken(user *server.User) (*sts.Credentials, error) {
+func (*dummyCredentials) GetSessionToken() (*sts.Credentials, error) {
 	accessKey := "access_key"
 	secretKey := "secret"
 	token := "token"


### PR DESCRIPTION
Starting work on https://github.com/AdRoll/hologram/issues/52.  

This merges the agent sts interactions into the server credentials object, since they are basically the same.  Adds a dictionary to both the client and server configs to allow for account aliases
