### PR TITLE
Allow usage of text file for users' data storage instead of LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The role of the hologram server must have assume role permissions.  See permissi
 
 For different projects it is recommended that you create IAM roles for each and have your developers assume these roles for testing the software. Hologram supports a command `hologram use <rolename>` which will fetch temporary credentials for this role instead of the default developer one until it is reset or another role is assumed.
 
-You will need to modify the Trusted Entities for each of these roles that you create so that the IAM instance profile you created for the Hologram Server can access them. The hologram user must have permission to assume that role. 
+You will need to modify the Trusted Entities for each of these roles that you create so that the IAM instance profile you created for the Hologram Server can access them. The hologram user must have permission to assume that role.
 
 ```json
     {
@@ -151,7 +151,7 @@ You will need to modify the Trusted Entities for each of these roles that you cr
 
 ### LDAP Based Roles
 
-Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`.
+Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableServerRoles` key to `true` in `config/server.json`.
 
 An LDAP group attribute will have to be chosen for user roles. By default `businessCategory` is chosen for this role since it is part of the core LDAP schema. The attribute used can be modified by editing the `roleAttribute` key in `config/server.json`. The value of this attribute should be the name of the group's role in AWS.
 

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -18,22 +18,23 @@ type LDAP struct {
 		DN       string `json:"dn"`
 		Password string `json:"password"`
 	} `json:"bind"`
-	UserAttr     string `json:"userattr"`
-	BaseDN       string `json:"basedn"`
-	Host         string `json:"host"`
-	InsecureLDAP bool   `json:"insecureldap"`
+	UserAttr        string `json:"userattr"`
+	BaseDN          string `json:"basedn"`
+	Host            string `json:"host"`
 	EnableLDAPRoles bool   `json:"enableldaproles"`
+	InsecureLDAP    bool   `json:"insecureldap"`
 	RoleAttribute   string `json:"roleattr"`
 	DefaultRoleAttr string `json:"defaultroleattr"`
 }
 
 type Config struct {
 	LDAP LDAP `json:"ldap"`
-	AWS struct {
+	AWS  struct {
 		Account     string `json:"account"`
 		DefaultRole string `json:"defaultrole"`
 	} `json:"aws"`
-	Stats        string `json:"stats"`
-	Listen       string `json:"listen"`
-	CacheTimeout int    `json:"cachetimeout"`
+	EnableServerRoles bool   `json:"enableserverroles"`
+	Stats             string `json:"stats"`
+	Listen            string `json:"listen"`
+	CacheTimeout      int    `json:"cachetimeout"`
 }

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -30,7 +30,7 @@ credentials to calling processes. No caching is done of these
 results other than that which the CredentialService does itself.
 */
 type CredentialService interface {
-	AssumeRole(user *User, role string, enableLDAPRoles bool) (*sts.Credentials, error)
+	AssumeRole(user *User, role string, enableServerRoles bool) (*sts.Credentials, error)
 }
 
 /*
@@ -77,12 +77,12 @@ func (s *directSessionTokenService) buildARN(role string) string {
 	return arn
 }
 
-func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLDAPRoles bool) (*sts.Credentials, error) {
+func (s *directSessionTokenService) AssumeRole(user *User, role string, enableServerRoles bool) (*sts.Credentials, error) {
 	var arn string = s.buildARN(role)
 
 	log.Debug("Checking ARN %s against user %s (with access %s)", arn, user.Username, user.ARNs)
 
-	if enableLDAPRoles {
+	if enableServerRoles {
 		found := false
 		for _, a := range user.ARNs {
 			a = s.buildARN(a)

--- a/server/persistent_keys_file.go
+++ b/server/persistent_keys_file.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"encoding/json"
+)
+
+type KeysMap map[string]map[string]interface{}
+
+type persistentKeysFile struct {
+	// Function that return the contents of the file
+	open func() ([]byte, error)
+	// Function to dump contents to the file
+	dump func([]byte) error
+	// Map from public ssh keys to a list of roles
+	keys KeysMap
+}
+
+func (pkf *persistentKeysFile) Load() error {
+	fileContent, err := pkf.open()
+	if err != nil {
+		return err
+	}
+
+	var keys KeysMap
+
+	if err := json.Unmarshal(fileContent, &keys); err != nil {
+		return err
+	}
+
+	pkf.keys = keys
+
+	return nil
+}
+
+func (pkf *persistentKeysFile) Keys() (KeysMap, error) {
+	if pkf.keys == nil {
+		err := pkf.Load()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return pkf.keys, nil
+}
+
+func (pkf *persistentKeysFile) Search(sshKey string) (map[string]interface{}, error) {
+	if pkf.keys == nil {
+		err := pkf.Load()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return pkf.keys[sshKey], nil
+}
+
+func NewPersistentKeysFile(open func() ([]byte, error), dump func([]byte) error) *persistentKeysFile {
+	return &persistentKeysFile{open: open, dump: dump}
+}

--- a/server/persistent_keys_file_test.go
+++ b/server/persistent_keys_file_test.go
@@ -1,0 +1,52 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/AdRoll/hologram/server"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestPersistentKeysFile(t *testing.T) {
+	data := `{
+        "KEY1": {"username": "user1", "roles": ["role1", "role11"]},
+        "KEY2": {"username": "user2", "roles": ["role2", "role22"]}
+    }`
+
+	open := func() ([]byte, error) {
+		return []byte(data), nil
+	}
+
+	dump := func([]byte) error {
+		return nil
+	}
+
+	Convey("Given data from keys file", t, func() {
+		Convey("Content from file should be loaded correctly", func() {
+			pkf := server.NewPersistentKeysFile(open, dump)
+			err := pkf.Load()
+			So(err, ShouldBeNil)
+		})
+
+		Convey("An existing key in file should be found", func() {
+			pkf := server.NewPersistentKeysFile(open, dump)
+
+			expected := map[string]interface{}{
+				"username": "user1",
+				"roles":    []interface{}{"role1", "role11"},
+			}
+			actual, err := pkf.Search("KEY1")
+			So(err, ShouldBeNil)
+			So(expected, ShouldResemble, actual)
+		})
+
+		Convey("An non existing key in file shouldn't be found", func() {
+			pkf := server.NewPersistentKeysFile(open, dump)
+
+			var expected map[string]interface{}
+			actual, err := pkf.Search("MISSING_KEY")
+			So(err, ShouldBeNil)
+			So(expected, ShouldResemble, actual)
+		})
+	})
+}

--- a/server/persistent_ldap.go
+++ b/server/persistent_ldap.go
@@ -29,7 +29,7 @@ func (pl *persistentLDAP) Search(searchRequest *ldap.SearchRequest) (*ldap.Searc
 }
 
 func (pl *persistentLDAP) Modify(modifyRequest *ldap.ModifyRequest) error {
-  if err := pl.conn.Modify(modifyRequest); err != nil && err.(*ldap.Error).ResultCode == ldap.ErrorNetwork {
+	if err := pl.conn.Modify(modifyRequest); err != nil && err.(*ldap.Error).ResultCode == ldap.ErrorNetwork {
 		pl.Refresh()
 		return pl.conn.Modify(modifyRequest)
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -45,7 +45,7 @@ type server struct {
 	ldapServer      LDAPImplementation
 	userAttr        string
 	baseDN          string
-	enableLDAPRoles bool
+	enableServerRoles bool
 	defaultRoleAttr string
 }
 
@@ -111,11 +111,11 @@ func (sm *server) HandleServerRequest(m protocol.MessageReadWriteCloser, r *prot
 		}
 
 		if user != nil {
-			creds, err := sm.credentials.AssumeRole(user, role, sm.enableLDAPRoles)
+			creds, err := sm.credentials.AssumeRole(user, role, sm.enableServerRoles)
 			if err != nil {
 				// Update user cache and try again
 				sm.userCache.Update()
-				creds, err := sm.credentials.AssumeRole(user, role, sm.enableLDAPRoles)
+				creds, err := sm.credentials.AssumeRole(user, role, sm.enableServerRoles)
 
 				if err != nil {
 					// error message from Amazon, so forward that on to the client
@@ -128,7 +128,7 @@ func (sm *server) HandleServerRequest(m protocol.MessageReadWriteCloser, r *prot
 					sm.stats.Counter(1.0, "errors.assumeRole", 1)
 
 					// Attempt to use the default role to fall back
-					creds, err = sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableLDAPRoles)
+					creds, err = sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableServerRoles)
 					if err == nil {
 						m.Write(makeCredsResponse(creds))
 					}
@@ -148,12 +148,12 @@ func (sm *server) HandleServerRequest(m protocol.MessageReadWriteCloser, r *prot
 		}
 
 		if user != nil {
-			creds, err := sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableLDAPRoles)
+			creds, err := sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableServerRoles)
 			if err != nil {
 				log.Errorf("Error trying to handle GetUserCredentials: %s", err.Error())
 				// Update user cache and try again
 				sm.userCache.Update()
-				creds, err = sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableLDAPRoles)
+				creds, err = sm.credentials.AssumeRole(user, user.DefaultRole, sm.enableServerRoles)
 				if err != nil {
 					errStr := fmt.Sprintf("Could not get user credentials. %s may not have been given Hologram access yet.", user.Username)
 					errMsg := &protocol.Message{
@@ -310,7 +310,7 @@ func New(userCache UserCache,
 	ldapServer LDAPImplementation,
 	userAttr string,
 	baseDN string,
-	enableLDAPRoles bool,
+	enableServerRoles bool,
 	defaultRoleAttr string) *server {
 	return &server{
 		credentials:     credentials,
@@ -321,7 +321,7 @@ func New(userCache UserCache,
 		ldapServer:      ldapServer,
 		userAttr:        userAttr,
 		baseDN:          baseDN,
-		enableLDAPRoles: enableLDAPRoles,
+		enableServerRoles: enableServerRoles,
 		defaultRoleAttr: defaultRoleAttr,
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -72,7 +72,7 @@ func (*dummyCredentials) GetSessionToken(user *server.User) (*sts.Credentials, e
 	}, nil
 }
 
-func (*dummyCredentials) AssumeRole(user *server.User, role string, enableLDAPRoles bool) (*sts.Credentials, error) {
+func (*dummyCredentials) AssumeRole(user *server.User, role string, enableServerRoles bool) (*sts.Credentials, error) {
 	return &sts.Credentials{
 		AccessKeyId:     "access_key",
 		SecretAccessKey: "secret",


### PR DESCRIPTION
This allows to store public SSH keys and roles in a text file as JSON instead of using LDAP.