### PR TITLE
Adding instructions for running as a non-root

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ The config files can set accountAliases, a dictionary from short name to account
   "accountAliases":{
     "dev":"arn:aws:iam::123456"
   }
-}```
+} 
+```
 
 With this config, `hologram use dev/service` would be equivalent to `hologram use arn:aws:iam::123456:role/service`
 
@@ -176,6 +177,18 @@ Hologram supports assigning roles based on a user's LDAP group. Roles can be tur
 An LDAP group attribute will have to be chosen for user roles. By default `businessCategory` is chosen for this role since it is part of the core LDAP schema. The attribute used can be modified by editing the `roleAttribute` key in `config/server.json`. The value of this attribute should be the name of the group's role in AWS.
 
 Users will have to be added to a group giving them access to the default role before they can use Hologram. It is recommended that a group such as `Hologram-Users` be created with attribute `businessCategory` set to the name of the default AWS role.
+
+### Running the agent as a user (Experimental, OSX only)
+
+Behavior is undefined in a multi-user environment.
+
+We can run the agent on a higher port and route port 80 through firewall rules using pf.  All supporting files are in `agent/support/darwin`.
+This requires passing `--port <port>` to the agent.  `com.adroll.hologram-launchagent.plist` can be used instead of `com.adroll.hologram.plist`.  This uses port 16925, and can be placed in `[~ or root]/Library/LaunchAgents` and loaded with launchd.
+
+To configure the firewall, place `pf.hologram.conf` in `/etc/pf/`, and `hologram.rules` in `/etc/pf.anchors/`.  You can load these with `sudo pfctl -ef /etc/pf/pf.hologram.conf`, or place `com.adroll.hologram-pfctl.plist` in `/Library/LaunchDaemons/` and load it with launchd.
+
+You also must ensure the log file, `/var/log/hologram.log` is writable by the user.
+
 
 ## Deployment Suggestions
 At AdRoll we have Hologram deployed in a fault-tolerant setup, with the following:

--- a/agent/support/darwin/com.adroll.hologram-launchagent.plist
+++ b/agent/support/darwin/com.adroll.hologram-launchagent.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.adroll.hologram</string>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/hologram-agent</string>
+    <string>--port</string>
+    <string>16925</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>/var/log/hologram.log</string>
+  <key>StandardErrorPath</key>
+  <string>/var/log/hologram.log</string>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/agent/support/darwin/com.adroll.hologram-pfctl.plist
+++ b/agent/support/darwin/com.adroll.hologram-pfctl.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer/DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>Label</key>
+        <string>com.adroll.hologram-pfctl.plist</string>
+        <key>Program</key>
+        <string>/sbin/pfctl</string>
+        <key>ProgramArguments</key>
+        <array>
+                <string>/sbin/pfctl</string>
+                <string>-e</string>
+                <string>-f</string>
+                <string>/etc/pf.hologram.conf</string>
+        </array>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>ServiceDescription</key>
+        <string>FreeBSD Packet Filter (pf) daemon</string>
+    <key>StandardErrorPath</key>
+        <string>/var/log/pf.log</string>
+        <key>StandardOutPath</key>
+        <string>/var/log/pf.log</string>
+</dict>
+</plist>

--- a/agent/support/darwin/hologram.rules
+++ b/agent/support/darwin/hologram.rules
@@ -1,0 +1,2 @@
+rdr pass on lo0 inet proto tcp from any to 169.254.169.254 port = 80 -> 169.254.169.254 port 16925
+

--- a/agent/support/darwin/pf.hologram.conf
+++ b/agent/support/darwin/pf.hologram.conf
@@ -1,0 +1,3 @@
+rdr-anchor "hologram"
+load anchor "hologram" from "/etc/pf.anchors/hologram.rules"
+

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -31,6 +31,7 @@ var (
 	dialAddress = flag.String("addr", "", "Address to connect to hologram server on.")
 	debugMode   = flag.Bool("debug", false, "Enable debug mode.")
 	configFile  = flag.String("conf", "/etc/hologram/agent.json", "Config file to load.")
+	httpPort    = flag.Int("port", 80, "Port for metadata service to listen on")
 	config      Config
 )
 
@@ -75,7 +76,7 @@ func main() {
 	// Startup the HTTP server and respond to requests.
 	listener, err := net.ListenTCP("tcp", &net.TCPAddr{
 		IP:   net.ParseIP("169.254.169.254"),
-		Port: 80,
+		Port: *httpPort,
 	})
 	if err != nil {
 		log.Errorf("Could not startup the metadata interface: %s", err)


### PR DESCRIPTION
We require running the agent as a user, been running it like this for a couple weeks