### PR TITLE
Enable using LDAP groups with different objectclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::AC
 
 ### LDAP Based Roles
 
-Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`.
+Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`. Hologram will only search for groups that have an `objectclass` attribute of `groupOfNames`. To change this, set the `groupClassAttr` in your `config/server/json` to the correct objectclass.
 
 An LDAP group attribute will have to be chosen for user roles. By default `businessCategory` is chosen for this role since it is part of the core LDAP schema. The attribute used can be modified by editing the `roleAttribute` key in `config/server.json`. The value of this attribute should be the name of the group's role in AWS.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The user must have permission to iam:GetUser on itself(resource "arn:aws:iam::AC
 
 ### LDAP Based Roles
 
-Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`. Hologram will only search for groups that have an `objectclass` attribute of `groupOfNames`. To change this, set the `groupClassAttr` in your `config/server/json` to the correct objectclass.
+Hologram supports assigning roles based on a user's LDAP group. Roles can be turned on by setting the `enableLDAPRoles` key to `true` in `config/server.json`. By default, Hologram will only search for groups that have an `objectclass` attribute of `groupOfNames`. To change this, set the `groupClassAttr` in your `config/server/json` to the correct objectclass.
 
 An LDAP group attribute will have to be chosen for user roles. By default `businessCategory` is chosen for this role since it is part of the core LDAP schema. The attribute used can be modified by editing the `roleAttribute` key in `config/server.json`. The value of this attribute should be the name of the group's role in AWS.
 

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -19,23 +19,24 @@ type LDAP struct {
 		DN       string `json:"dn"`
 		Password string `json:"password"`
 	} `json:"bind"`
-	UserAttr     string `json:"userattr"`
-	BaseDN       string `json:"basedn"`
-	Host         string `json:"host"`
-	InsecureLDAP bool   `json:"insecureldap"`
+	UserAttr        string `json:"userattr"`
+	BaseDN          string `json:"basedn"`
+	Host            string `json:"host"`
+	InsecureLDAP    bool   `json:"insecureldap"`
 	EnableLDAPRoles bool   `json:"enableldaproles"`
 	RoleAttribute   string `json:"roleattr"`
 	DefaultRoleAttr string `json:"defaultroleattr"`
+	GroupClassAttr  string `json:"groupclassattr"`
 }
 
 type Config struct {
 	LDAP LDAP `json:"ldap"`
-	AWS struct {
+	AWS  struct {
 		Account     string `json:"account"`
 		DefaultRole string `json:"defaultrole"`
 	} `json:"aws"`
-	Stats        string `json:"stats"`
-	Listen       string `json:"listen"`
-	CacheTimeout int    `json:"cachetimeout"`
-	AccountAliases   map[string]string `json:"accountAliases`
+	Stats          string            `json:"stats"`
+	Listen         string            `json:"listen"`
+	CacheTimeout   int               `json:"cachetimeout"`
+	AccountAliases map[string]string `json:"accountAliases`
 }

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -76,6 +76,7 @@ func main() {
 		enableLDAPRoles  = flag.Bool("ldaproles", false, "Enable role support using LDAP directory.")
 		roleAttribute    = flag.String("roleattribute", "", "Group attribute to get role from.")
 		defaultRoleAttr  = flag.String("defaultroleattr", "", "User attribute to check to determine a user's default role.")
+		groupClassAttr   = flag.String("groupclassattr", "", "LDAP objectclass to determine the groups in LDAP.")
 		defaultRole      = flag.String("role", "", "AWS role to assume by default.")
 		configFile       = flag.String("conf", "/etc/hologram/server.json", "Config file to load.")
 		cacheTimeout     = flag.Int("cachetime", 3600, "Time in seconds after which to refresh LDAP user cache.")
@@ -150,6 +151,12 @@ func main() {
 		config.LDAP.RoleAttribute = *roleAttribute
 	}
 
+	if *groupClassAttr != "" {
+		config.LDAP.GroupClassAttr = *groupClassAttr
+	} else if config.LDAP.GroupClassAttr == "" {
+		config.LDAP.GroupClassAttr = "groupOfNames"
+	}
+
 	if *cacheTimeout != 3600 {
 		config.CacheTimeout = *cacheTimeout
 	}
@@ -186,7 +193,8 @@ func main() {
 	}
 
 	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN,
-		config.LDAP.EnableLDAPRoles, config.LDAP.RoleAttribute, config.AWS.DefaultRole, config.LDAP.DefaultRoleAttr)
+		config.LDAP.EnableLDAPRoles, config.LDAP.RoleAttribute, config.AWS.DefaultRole, config.LDAP.DefaultRoleAttr,
+		config.LDAP.GroupClassAttr)
 	if err != nil {
 		log.Errorf("Top-level error in LDAPUserCache layer: %s", err.Error())
 		os.Exit(1)

--- a/config/server.json
+++ b/config/server.json
@@ -8,8 +8,9 @@
     "userattr": "cn",
     "basedn": "dc=domain,dc=local",
     "enableldaproles": false,
-    "roleattr": "businessCategory"
-    "defaultroleattr": "employeeType"
+    "roleattr": "businessCategory",
+    "defaultroleattr": "employeeType",
+    "groupclassattr": "groupOfNames"
   },
   "aws": {
     "account":      "123456789010",

--- a/server/usercache.go
+++ b/server/usercache.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/AdRoll/hologram/log"
@@ -67,6 +68,7 @@ type ldapUserCache struct {
 	roleAttribute   string
 	defaultRole     string
 	defaultRoleAttr string
+	groupClassAttr  string
 }
 
 /*
@@ -83,7 +85,7 @@ func (luc *ldapUserCache) Update() error {
 			luc.baseDN,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
 			0, 0, false,
-			"(objectClass=groupOfNames)",
+			fmt.Sprintf("(objectClass=%s)", luc.groupClassAttr),
 			[]string{luc.roleAttribute},
 			nil,
 		)
@@ -199,7 +201,7 @@ func (luc *ldapUserCache) Authenticate(username string, challenge []byte, sshSig
 /*
 	NewLDAPUserCache returns a properly-configured LDAP cache.
 */
-func NewLDAPUserCache(server LDAPImplementation, stats g2s.Statter, userAttr string, baseDN string, enableLDAPRoles bool, roleAttribute string, defaultRole string, defaultRoleAttr string) (*ldapUserCache, error) {
+func NewLDAPUserCache(server LDAPImplementation, stats g2s.Statter, userAttr string, baseDN string, enableLDAPRoles bool, roleAttribute string, defaultRole string, defaultRoleAttr string, groupClassAttr string) (*ldapUserCache, error) {
 	retCache := &ldapUserCache{
 		users:           map[string]*User{},
 		groups:          map[string][]string{},
@@ -211,6 +213,7 @@ func NewLDAPUserCache(server LDAPImplementation, stats g2s.Statter, userAttr str
 		roleAttribute:   roleAttribute,
 		defaultRole:     defaultRole,
 		defaultRoleAttr: defaultRoleAttr,
+		groupClassAttr:  groupClassAttr,
 	}
 
 	updateError := retCache.Update()

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -128,7 +128,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s := &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -202,7 +202,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s = &StubLDAPServer{
 			Keys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 


### PR DESCRIPTION
Hologram previously only searched for groups that had an objectclass of
groupOfNames and wasn't configurable. This makes that attribute filter
configurable.

Fixes #87