### PR TITLE
Configurable session timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.7
-  - tip
 
 install:
   - git clone https://github.com/pote/gpm.git && cd gpm && ./configure

--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -19,15 +19,16 @@ type LDAP struct {
 		DN       string `json:"dn"`
 		Password string `json:"password"`
 	} `json:"bind"`
-	UserAttr        string `json:"userattr"`
-	BaseDN          string `json:"basedn"`
-	Host            string `json:"host"`
-	InsecureLDAP    bool   `json:"insecureldap"`
-	EnableLDAPRoles bool   `json:"enableldaproles"`
-	RoleAttribute   string `json:"roleattr"`
-	DefaultRoleAttr string `json:"defaultroleattr"`
-	GroupClassAttr  string `json:"groupclassattr"`
-	PubKeysAttr     string `json:"pubkeysattr"`
+	UserAttr           string `json:"userattr"`
+	BaseDN             string `json:"basedn"`
+	Host               string `json:"host"`
+	InsecureLDAP       bool   `json:"insecureldap"`
+	EnableLDAPRoles    bool   `json:"enableldaproles"`
+	RoleAttribute      string `json:"roleattr"`
+	DefaultRoleAttr    string `json:"defaultroleattr"`
+	GroupClassAttr     string `json:"groupclassattr"`
+	PubKeysAttr        string `json:"pubkeysattr"`
+	RoleTimeoutAttr    string `json:"roletimeoutattr"`
 }
 
 type Config struct {

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -82,6 +82,7 @@ func main() {
 		cacheTimeout     = flag.Int("cachetime", 3600, "Time in seconds after which to refresh LDAP user cache.")
 		debugMode        = flag.Bool("debug", false, "Enable debug mode.")
 		pubKeysAttr      = flag.String("pubkeysattr", "", "Name of the LDAP user attribute containing ssh public key data.")
+		roleTimeoutAttr  = flag.String("roletimeoutattr", "", "Name of the LDAP group attribute containing role timeout in seconds.")
 		config           Config
 	)
 
@@ -164,6 +165,12 @@ func main() {
 		config.LDAP.PubKeysAttr = "sshPublicKey"
 	}
 
+	if *roleTimeoutAttr != "" {
+		config.LDAP.RoleAttribute = *roleTimeoutAttr
+	} else if config.LDAP.RoleAttribute == "" {
+		config.LDAP.RoleTimeoutAttr = ""
+	}
+
 	if *cacheTimeout != 3600 {
 		config.CacheTimeout = *cacheTimeout
 	}
@@ -209,7 +216,7 @@ func main() {
 
 	serverHandler := server.New(ldapCache, credentialsService, config.AWS.DefaultRole, stats, ldapServer,
 		config.LDAP.UserAttr, config.LDAP.BaseDN, config.LDAP.EnableLDAPRoles, config.LDAP.DefaultRoleAttr,
-		config.LDAP.PubKeysAttr)
+		config.LDAP.PubKeysAttr, config.LDAP.RoleTimeoutAttr)
 	server, err := remote.NewServer(config.Listen, serverHandler.HandleConnection)
 
 	// Wait for a signal from the OS to shutdown.

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -166,8 +166,8 @@ func main() {
 	}
 
 	if *roleTimeoutAttr != "" {
-		config.LDAP.RoleAttribute = *roleTimeoutAttr
-	} else if config.LDAP.RoleAttribute == "" {
+		config.LDAP.RoleTimeoutAttr = *roleTimeoutAttr
+	} else if config.LDAP.RoleTimeoutAttr == "" {
 		config.LDAP.RoleTimeoutAttr = ""
 	}
 
@@ -208,7 +208,7 @@ func main() {
 
 	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN,
 		config.LDAP.EnableLDAPRoles, config.LDAP.RoleAttribute, config.AWS.DefaultRole, config.LDAP.DefaultRoleAttr,
-		config.LDAP.GroupClassAttr, config.LDAP.PubKeysAttr)
+		config.LDAP.GroupClassAttr, config.LDAP.PubKeysAttr, config.LDAP.RoleTimeoutAttr)
 	if err != nil {
 		log.Errorf("Top-level error in LDAPUserCache layer: %s", err.Error())
 		os.Exit(1)

--- a/config/server.json
+++ b/config/server.json
@@ -12,7 +12,7 @@
     "defaultroleattr": "employeeType",
     "groupclassattr": "groupOfNames",
     "pubkeysattr": "sshPublicKey",
-    "roletimeoutattr": "description"
+    "roletimeoutattr": "timeoutAttribute"
   },
   "aws": {
     "account":      "123456789010",

--- a/config/server.json
+++ b/config/server.json
@@ -11,7 +11,8 @@
     "roleattr": "businessCategory",
     "defaultroleattr": "employeeType",
     "groupclassattr": "groupOfNames",
-    "pubkeysattr": "sshPublicKey"
+    "pubkeysattr": "sshPublicKey",
+    "roletimeoutattr": "description"
   },
   "aws": {
     "account":      "123456789010",

--- a/server/credentials.go
+++ b/server/credentials.go
@@ -97,7 +97,7 @@ func (s *directSessionTokenService) AssumeRole(user *User, role string, enableLD
 				a = BuildARN(a, s.iamAccount, s.accountAliases)
 				if arn == a {
 					found = true
-					timeout = group.timeout
+					timeout = group.Timeout
 					break
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ type server struct {
 	enableLDAPRoles bool
 	defaultRoleAttr string
 	pubKeysAttr     string
+	roleTimeoutAttr string
 }
 
 /*
@@ -317,7 +318,8 @@ func New(userCache UserCache,
 	baseDN string,
 	enableLDAPRoles bool,
 	defaultRoleAttr string,
-	pubKeysAttr string) *server {
+	pubKeysAttr string,
+	roleTimeoutAttr string) *server {
 	return &server{
 		credentials:     credentials,
 		authenticator:   userCache,
@@ -330,5 +332,6 @@ func New(userCache UserCache,
 		enableLDAPRoles: enableLDAPRoles,
 		defaultRoleAttr: defaultRoleAttr,
 		pubKeysAttr:     pubKeysAttr,
+		roleTimeoutAttr: roleTimeoutAttr,
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -139,7 +139,7 @@ func TestServerStateMachine(t *testing.T) {
 			sshKeys:  []string{},
 			req:      neededModifyRequest,
 		}
-		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com", false, "", "sshPublicKey")
+		testServer := server.New(authenticator, &dummyCredentials{}, "default", g2s.Noop(), ldap, "cn", "dc=testdn,dc=com", false, "", "sshPublicKey", "ref")
 		r, w := io.Pipe()
 
 		testConnection := protocol.NewMessageConnection(ReadWriter(r, w))

--- a/server/usercache.go
+++ b/server/usercache.go
@@ -38,7 +38,7 @@ type User struct {
 
 type Group struct {
 	ARNs    []string
-	timeout int64
+	Timeout int64
 }
 
 /*
@@ -117,16 +117,17 @@ func (luc *ldapUserCache) Update() error {
 					timeoutStr := entries[0]
 					timeout, err = strconv.ParseInt(timeoutStr, 10, 64)
 					if err != nil {
+						// Default back to a 1 hour Timeout if there is a parsing error
 						timeout = int64(3600)
-						log.Warning("Encountered error parsing timeout %s on group %s", timeoutStr, dn)
+						log.Warning("Encountered error parsing Timeout %s on group %s", timeoutStr, dn)
 					}
 				}
 			}
 
-			log.Debug("Adding %s to %s with timeout %d", ARNs, dn, timeout)
+			log.Debug("Adding %s to %s with Timeout %d", ARNs, dn, timeout)
 			luc.groups[dn] = &Group{
 				ARNs:    ARNs,
-				timeout: timeout,
+				Timeout: timeout,
 			}
 		}
 	}
@@ -190,6 +191,10 @@ func (luc *ldapUserCache) Update() error {
 
 func (luc *ldapUserCache) Users() map[string]*User {
 	return luc.users
+}
+
+func (luc *ldapUserCache) Groups() map[string]*Group {
+	return luc.groups
 }
 
 func (luc *ldapUserCache) _verify(username string, challenge []byte, sshSig *ssh.Signature) (

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -141,7 +141,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s := &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -215,7 +215,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s = &StubLDAPServer{
 			Keys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -238,7 +238,7 @@ func TestLDAPUserCache(t *testing.T) {
 			Keys:      []string{nonAuthorizedKey},
 			OtherKeys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "otherKeysAttribute")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "otherKeysAttribute", "")
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -80,6 +80,7 @@ func (sls *StubLDAPServer) Search(s *ldap.SearchRequest) (*ldap.SearchResult, er
 	return &ldap.SearchResult{
 		Entries: []*ldap.Entry{
 			&ldap.Entry{
+				DN: "testdn_0",
 				Attributes: []*ldap.EntryAttribute{
 					&ldap.EntryAttribute{
 						Name:   "cn",
@@ -92,6 +93,39 @@ func (sls *StubLDAPServer) Search(s *ldap.SearchRequest) (*ldap.SearchResult, er
 					&ldap.EntryAttribute{
 						Name:   "otherKeysAttribute",
 						Values: sls.OtherKeys,
+					},
+					&ldap.EntryAttribute{
+						Name:   "roleAttribute",
+						Values: []string{"engineer"},
+					},
+					&ldap.EntryAttribute{
+						Name:   "timeoutAttribute",
+						Values: []string{"7200"},
+					},
+				},
+			},
+			&ldap.Entry{
+				DN: "testdn_1",
+				Attributes: []*ldap.EntryAttribute{
+					&ldap.EntryAttribute{
+						Name:   "cn",
+						Values: []string{"testuser"},
+					},
+					&ldap.EntryAttribute{
+						Name:   "sshPublicKey",
+						Values: sls.Keys,
+					},
+					&ldap.EntryAttribute{
+						Name:   "otherKeysAttribute",
+						Values: sls.OtherKeys,
+					},
+					&ldap.EntryAttribute{
+						Name:   "roleAttribute",
+						Values: []string{"engineer"},
+					},
+					&ldap.EntryAttribute{
+						Name:   "timeoutAttribute",
+						Values: []string{"not_an_integer"},
 					},
 				},
 			},
@@ -112,6 +146,7 @@ func randomBytes(length int) []byte {
 
 	return buf
 }
+
 
 func TestLDAPUserCache(t *testing.T) {
 	Convey("Given an LDAP user cache connected to our server", t, func() {
@@ -263,5 +298,42 @@ func TestLDAPUserCache(t *testing.T) {
 				So(verifiedUser, ShouldNotBeNil)
 			})
 		})
+
+		s = &StubLDAPServer{
+			Keys: []string{keyValue, testPublicKey},
+		}
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "timeoutAttribute")
+		So(err, ShouldBeNil)
+		So(lc, ShouldNotBeNil)
+
+		Convey ("If a role timeout attribute is set then it should be respected", func() {
+			Convey("Ensure LDAP user cache is updated with a non-default role timeout", func() {
+				groups := lc.Groups()
+				So(len(groups), ShouldEqual, 1)
+				So(len(groups["testdn_0"].ARNs), ShouldEqual, 1)
+				So(groups["testdn_0"].ARNs[0], ShouldEqual, "engineer")
+				So(groups["testdn_0"].Timeout, ShouldEqual, int64(7200))
+			})
+
+			Convey("Ensure that if an invalid timeout is set in LDAP the default is used", func() {
+				groups := lc.Groups()
+				So(len(groups["testdn_1"].ARNs), ShouldEqual, 1)
+				So(groups["testdn_1"].ARNs[0], ShouldEqual, "engineer")
+				So(groups["testdn_1"].Timeout, ShouldEqual, int64(3600))
+			})
+		})
+
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "")
+		So(err, ShouldBeNil)
+		So(lc, ShouldNotBeNil)
+
+		Convey ("If no role timeout attribute is set, the default should be used.", func() {
+			groups := lc.Groups()
+			So(len(groups), ShouldEqual, 1)
+			So(len(groups["testdn_0"].ARNs), ShouldEqual, 1)
+			So(groups["testdn_0"].ARNs[0], ShouldEqual, "engineer")
+			So(groups["testdn_0"].Timeout, ShouldEqual, int64(3600))
+		})
+
 	})
 }


### PR DESCRIPTION
The hard coded 3600 second life on session tokens is often problematic when working on tasks that require a longer timeout, such as a long-running local script or working in the console via Holochrome. 

This PR allows each role to have a configurable timeout based on a configurable LDAP group attribute. This means an `engineer` role, for example, could have a 4 hour timeout and a more permissive `god` role could have something like a 30 minute timeout. 