### PR TITLE
Add an IP allow list for the dockers

### DIFF
--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -71,7 +71,7 @@ func makeSecure(handler func(http.ResponseWriter, *http.Request), mds *metadataS
 		// Must make sure the remote ip is localhost, otherwise clients on the same network segment could
 		// potentially route traffic via 169.254.169.254:80
 		if !allowedIP {
-			msg := fmt.Sprintf("Access denied from non-localhost address: %s, not in the set of allowed IPs", ip)
+			msg := fmt.Sprintf("Access denied from %s, not in the set of allowed IPs", ip)
 			log.Info("Rejecting connection from ip %s", ip)
 			http.Error(w, msg, http.StatusUnauthorized)
 			return

--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -205,8 +205,8 @@ func NewMetadataService(listener net.Listener, creds credentialsSource, extraAll
 	}
 
 	// Add default allowed nets to the list
-	for _, cidr := range []string{"127.0.0.1/32", "169.254.169.254/32"} {
-		_, ipNet, _ := net.ParseCIDR(cidr)
+	for _, ip := range []net.IP{net.IPv4(127, 0, 0, 1), net.IPv4(169, 254, 169, 254)} {
+		ipNet := &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
 		allowIps = append(allowIps, ipNet)
 	}
 

--- a/agent/metadata_service.go
+++ b/agent/metadata_service.go
@@ -73,7 +73,7 @@ func makeSecure(handler func(http.ResponseWriter, *http.Request), mds *metadataS
 		// Must make sure the remote ip is localhost, otherwise clients on the same network segment could
 		// potentially route traffic via 169.254.169.254:80
 		if ip != `127.0.0.1` && ip != `169.254.169.254` && !allowedIP {
-			msg := fmt.Sprintf("Access denied from non-localhost address: %s", ip)
+			msg := fmt.Sprintf("Access denied from non-localhost address: %s, allowed IPs: %v", ip, mds.IPAllowList)
 			http.Error(w, msg, http.StatusUnauthorized)
 			return
 		}
@@ -199,14 +199,14 @@ func (mds *metadataService) getCredentials(w http.ResponseWriter, r *http.Reques
 NewMetadataService returns a properly-initialized metadataService for use.
 */
 func NewMetadataService(listener net.Listener, creds CredentialsSource, allowList *[]string) (MetadataService, error) {
-  IPAllowList := make([]string, 0)
-  if allowList != nil {
-      IPAllowList = *allowList
-  }
+	IPAllowList := make([]string, 0)
+	if allowList != nil {
+		IPAllowList = *allowList
+	}
 	return &metadataService{
 		listener:    listener,
 		creds:       creds,
-    IPAllowList: IPAllowList,
+		IPAllowList: IPAllowList,
 	}, nil
 }
 

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -53,8 +53,9 @@ func TestMetadataService(t *testing.T) {
 			SessionToken:    &token,
 			Expiration:      &expiration,
 		}}
+    allowedIps := []string{"172.0.0.1"}
 
-		service, err := NewMetadataService(testListener, dummyCreds)
+		service, err := NewMetadataService(testListener, dummyCreds, &allowedIps)
 
 		So(err, ShouldBeNil)
 		So(service, ShouldNotBeNil)

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -18,8 +18,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -34,6 +37,16 @@ type dummyCredentialsSource struct {
 
 func (d *dummyCredentialsSource) GetCredentials() (*sts.Credentials, error) {
 	return d.creds, d.err
+}
+
+func request(port int, path string) []byte {
+	url := fmt.Sprintf("http://localhost:%v%v", port, path)
+	response, err := http.Get(url)
+	So(err, ShouldBeNil)
+	So(response.StatusCode, ShouldEqual, 200)
+	respBodyBytes := make([]byte, response.ContentLength)
+	response.Body.Read(respBodyBytes)
+	return respBodyBytes
 }
 
 func TestMetadataService(t *testing.T) {
@@ -53,8 +66,7 @@ func TestMetadataService(t *testing.T) {
 			SessionToken:    &token,
 			Expiration:      &expiration,
 		}}
-		_, ipNet, err := net.ParseCIDR("172.0.0.2/32")
-		allowedIps := []*net.IPNet{ipNet}
+		allowedIps := []*net.IPNet{}
 
 		service, err := NewMetadataService(testListener, dummyCreds, allowedIps)
 
@@ -128,12 +140,71 @@ func TestMetadataService(t *testing.T) {
 	})
 }
 
-func request(port int, path string) []byte {
-	url := fmt.Sprintf("http://localhost:%v%v", port, path)
-	response, err := http.Get(url)
-	So(err, ShouldBeNil)
-	So(response.StatusCode, ShouldEqual, 200)
-	respBodyBytes := make([]byte, response.ContentLength)
-	response.Body.Read(respBodyBytes)
-	return respBodyBytes
+func TestMakeSecureAllowedIPs(t *testing.T) {
+	Convey("Given a test handler with allowed IP", t, func() {
+		allowedIP := net.IPv4(172, 17, 0, 1)
+		notAllowed := net.IPv4(172, 17, 0, 2)
+		testListener, err := net.ListenTCP("tcp", &net.TCPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 0,
+		})
+		accessKey := "access_key"
+		secretKey := "secret"
+		token := "token"
+		expiration := time.Date(2014, 10, 22, 12, 21, 17, 00, time.UTC)
+		dummyCreds := &dummyCredentialsSource{creds: &sts.Credentials{
+			AccessKeyId:     &accessKey,
+			SecretAccessKey: &secretKey,
+			SessionToken:    &token,
+			Expiration:      &expiration,
+		}}
+
+		allowedIps := []*net.IPNet{&net.IPNet{
+			IP:   allowedIP,
+			Mask: net.CIDRMask(32, 32),
+		}}
+
+		mds := &metadataService{
+			listener: testListener,
+			creds:    dummyCreds,
+			allowIps: allowedIps,
+		}
+
+		insecureHandler := func(w http.ResponseWriter, r *http.Request) {
+			io.WriteString(w, "Coveted secret")
+		}
+
+		handler := makeSecure(insecureHandler, mds)
+
+		So(err, ShouldBeNil)
+		So(mds, ShouldNotBeNil)
+
+		url := fmt.Sprintf("http://localhost:%v%v", mds.Port(), "/latest/meta-data/iam/security-credentials/hologram-access")
+
+		Convey("It should respond correctly to allowed IPs", func() {
+			req := httptest.NewRequest("GET", url, nil)
+			req.RemoteAddr = fmt.Sprintf("%s:80", allowedIP)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			So(resp.StatusCode, ShouldEqual, 200)
+			So(string(body), ShouldEqual, "Coveted secret")
+		})
+
+		Convey("It should block other IPs", func() {
+			req := httptest.NewRequest("GET", url, nil)
+			req.RemoteAddr = fmt.Sprintf("%s:80", notAllowed)
+			w := httptest.NewRecorder()
+			handler(w, req)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			So(resp.StatusCode, ShouldEqual, 401)
+			So(string(body), ShouldNotEqual, "Coveted secret")
+		})
+	})
 }

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -53,9 +53,10 @@ func TestMetadataService(t *testing.T) {
 			SessionToken:    &token,
 			Expiration:      &expiration,
 		}}
-		allowedIps := map[string]interface{}{"172.0.0.1": true}
+		_, ipNet, err := net.ParseCIDR("172.0.0.2/32")
+		allowedIps := []*net.IPNet{ipNet}
 
-		service, err := NewMetadataService(testListener, dummyCreds, &allowedIps)
+		service, err := NewMetadataService(testListener, dummyCreds, allowedIps)
 
 		So(err, ShouldBeNil)
 		So(service, ShouldNotBeNil)

--- a/agent/metadata_service_test.go
+++ b/agent/metadata_service_test.go
@@ -53,7 +53,7 @@ func TestMetadataService(t *testing.T) {
 			SessionToken:    &token,
 			Expiration:      &expiration,
 		}}
-    allowedIps := []string{"172.0.0.1"}
+		allowedIps := map[string]interface{}{"172.0.0.1": true}
 
 		service, err := NewMetadataService(testListener, dummyCreds, &allowedIps)
 

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -20,4 +20,5 @@ Config represents the top-level configuration values required by the application
 type Config struct {
 	Host           string            `json:"host"`
 	AccountAliases map[string]string `json:"accountAliases"`
+	IPAllowList    []string          `json:"ipAllowList"`
 }

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -20,5 +20,5 @@ Config represents the top-level configuration values required by the application
 type Config struct {
 	Host           string            `json:"host"`
 	AccountAliases map[string]string `json:"accountAliases"`
-	IPAllowList    []string          `json:"ipAllowList"`
+	AllowIps       []string          `json:"allowIps"`
 }

--- a/cmd/hologram-agent/config.go
+++ b/cmd/hologram-agent/config.go
@@ -18,7 +18,7 @@ package main
 Config represents the top-level configuration values required by the application.
 */
 type Config struct {
-	Host           string            `json:"host"`
-	AccountAliases map[string]string `json:"accountAliases"`
-	AllowIps       []string          `json:"allowIps"`
+	Host            string            `json:"host"`
+	AccountAliases  map[string]string `json:"accountAliases"`
+	ExtraAllowedIps []string          `json:"extraAllowedIps"`
 }

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	credsManager := agent.NewCredentialsExpirationManager()
 
-	mds, err := agent.NewMetadataService(listener, credsManager)
+	mds, err := agent.NewMetadataService(listener, credsManager, &config.IPAllowList)
 	if err != nil {
 		log.Errorf("Could not create metadata service: %s", err.Error())
 		os.Exit(1)

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -97,7 +97,7 @@ func main() {
 	credsManager := agent.NewCredentialsExpirationManager()
 
 	extraIps := []*net.IPNet{}
-	log.Info("Non localhost allowed addresses: %v", config.ExtraAllowedIps)
+	log.Info("Extra allowed addresses: %v", config.ExtraAllowedIps)
 	for _, ip := range config.ExtraAllowedIps {
 		ipNet, err := ensureCIDR(ip)
 		if err == nil {

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -96,18 +96,18 @@ func main() {
 
 	credsManager := agent.NewCredentialsExpirationManager()
 
-	allowIps := []*net.IPNet{}
-	log.Info("Non localhost allowed addresses: %v", config.AllowIps)
-	for _, ip := range config.AllowIps {
+	extraIps := []*net.IPNet{}
+	log.Info("Non localhost allowed addresses: %v", config.ExtraAllowedIps)
+	for _, ip := range config.ExtraAllowedIps {
 		ipNet, err := ensureCIDR(ip)
 		if err == nil {
-			allowIps = append(allowIps, ipNet)
+			extraIps = append(extraIps, ipNet)
 		} else {
 			log.Warning("Ignoring invalid IP: %s", ip)
 		}
 	}
 
-	mds, err := agent.NewMetadataService(listener, credsManager, allowIps)
+	mds, err := agent.NewMetadataService(listener, credsManager, extraIps)
 	if err != nil {
 		log.Errorf("Could not create metadata service: %s", err.Error())
 		os.Exit(1)

--- a/cmd/hologram-agent/main.go
+++ b/cmd/hologram-agent/main.go
@@ -80,7 +80,13 @@ func main() {
 
 	credsManager := agent.NewCredentialsExpirationManager()
 
-	mds, err := agent.NewMetadataService(listener, credsManager, &config.IPAllowList)
+	allowIps := make(map[string]interface{})
+	log.Info("Non localhost allowed addresses: %v", config.AllowIps)
+	for _, ip := range config.AllowIps {
+		allowIps[ip] = true
+	}
+
+	mds, err := agent.NewMetadataService(listener, credsManager, &allowIps)
 	if err != nil {
 		log.Errorf("Could not create metadata service: %s", err.Error())
 		os.Exit(1)

--- a/config/agent.json
+++ b/config/agent.json
@@ -1,3 +1,4 @@
 {
-  "host": ""
+  "host": "",
+  "allowIps": []
 }

--- a/config/agent.json
+++ b/config/agent.json
@@ -1,4 +1,4 @@
 {
   "host": "",
-  "allowIps": []
+  "extraAllowedIps": []
 }


### PR DESCRIPTION
This ip allow list fixes this error when using the service from within linux docker.

## Before
```
~
❯ docker run --rm -it --entrypoint '' amazon/aws-cli curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/hologram-access
Access denied from non-localhost address: 172.17.0.2
```

```
~
❯ curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/hologram-access
{"Code":"Success","LastUpdated":"2020-12-16T22:51:44Z","Type":"AWS-HMAC","AccessKeyId":"[REDACTED]","SecretAccessKey":"[REDACTED]","Token":"[REDACTED]","Expiration":"2020-12-17T02:50:03Z"}%
~
❯ docker run --rm -it --entrypoint '' amazon/aws-cli curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/hologram-access
{"Code":"Success","LastUpdated":"2020-12-16T22:51:50Z","Type":"AWS-HMAC","AccessKeyId":"[REDACTED]","SecretAccessKey":"[REDACTED]","Token":"[REDACTED]","Expiration":"2020-12-17T02:50:03Z"}%
```

To test with extra allowed IPs (the gateway docker uses in Linux) use the following configuration:

```json
{
  "host": "the.usual.url",
  "extraAllowedIps": ["172.17.0.2"]
}
```
