### PR TITLE
Add vscode debugging of cmd and agent

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "hologram-cmd",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hologram/main.go",
+      "args": ["me"]
+    },
+    {
+      "name": "hologram-agent",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/hologram-agent",
+      "args": [
+        "--conf", "${workspaceFolder}/agent.json",
+        "--debug"
+      ],
+      // "sudo": true,
+      "preLaunchTask": "rm_sock"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,9 @@
+{
+    "version": "2.0.0",
+    "tasks": [{
+        "label": "rm_sock",
+        "command": "rm", // Could be any other shell command
+        "args": ["/var/run/hologram.sock"],
+        "type": "shell"
+    }]
+}


### PR DESCRIPTION
Basic debugging using vscode.

I was able to step through the code in vscode after running this locally.

```
go mod init github.com/AdRoll/hologram
```