### PR TITLE
[SRE-4520] Update golang container build failures for DR testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,7 @@ artifacts/
 deploy/healthcheck
 .hologram-package-config
 .idea/
+agent/support/output.tar.gz
+cmd/hologram-agent/hologram-agent
+cmd/hologram/hologram
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.19.4
 
-# Switch to archive Debian
+# Switch to archive in sources.list for Debian 9
 RUN echo 'deb http://archive.debian.org/debian stretch main contrib non-free' >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.19.4
 
-RUN echo 'deb http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list
+# Switch to archive Debian
+RUN echo 'deb http://archive.debian.org/debian stretch main contrib non-free' >> /etc/apt/sources.list
 
 RUN apt-get update && apt-get install -y \
                                 cpio \

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.0
+FROM debian:10.0
 
 RUN apt-get update && apt-get install rsyslog ca-certificates -y
 COPY objects/hologram-server.deb /tmp/hologram-server.deb


### PR DESCRIPTION
* Adds archive to `sources.list`
* Small `.gitignore` changes to ignore build output files