### PR TITLE
Give an option to disable Updating the user/group cache when a user's sshkey isn't found in the cache. 

### DIFF
--- a/cmd/hologram-server/config.go
+++ b/cmd/hologram-server/config.go
@@ -19,16 +19,17 @@ type LDAP struct {
 		DN       string `json:"dn"`
 		Password string `json:"password"`
 	} `json:"bind"`
-	UserAttr           string `json:"userattr"`
-	BaseDN             string `json:"basedn"`
-	Host               string `json:"host"`
-	InsecureLDAP       bool   `json:"insecureldap"`
-	EnableLDAPRoles    bool   `json:"enableldaproles"`
-	RoleAttribute      string `json:"roleattr"`
-	DefaultRoleAttr    string `json:"defaultroleattr"`
-	GroupClassAttr     string `json:"groupclassattr"`
-	PubKeysAttr        string `json:"pubkeysattr"`
-	RoleTimeoutAttr    string `json:"roletimeoutattr"`
+	UserAttr        string `json:"userattr"`
+	BaseDN          string `json:"basedn"`
+	Host            string `json:"host"`
+	InsecureLDAP    bool   `json:"insecureldap"`
+	EnableLDAPRoles bool   `json:"enableldaproles"`
+	RoleAttribute   string `json:"roleattr"`
+	DefaultRoleAttr string `json:"defaultroleattr"`
+	GroupClassAttr  string `json:"groupclassattr"`
+	PubKeysAttr     string `json:"pubkeysattr"`
+	RoleTimeoutAttr string `json:"roletimeoutattr"`
+	NoUpdateAttr    bool   `json:"noupdateattr"`
 }
 
 type Config struct {

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -177,7 +177,8 @@ func main() {
 	}
 
 	if *noUpdateAttr != false {
-		config.LDAP.NoUpdateAttr = true
+		config.LDAP.NoUpdateAttr = *noUpdateAttr
+
 	}
 
 	var stats g2s.Statter

--- a/cmd/hologram-server/main.go
+++ b/cmd/hologram-server/main.go
@@ -83,6 +83,7 @@ func main() {
 		debugMode        = flag.Bool("debug", false, "Enable debug mode.")
 		pubKeysAttr      = flag.String("pubkeysattr", "", "Name of the LDAP user attribute containing ssh public key data.")
 		roleTimeoutAttr  = flag.String("roletimeoutattr", "", "Name of the LDAP group attribute containing role timeout in seconds.")
+		noUpdateAttr     = flag.Bool("noUpdate", false, "Disable cache update on missed user.")
 		config           Config
 	)
 
@@ -175,6 +176,10 @@ func main() {
 		config.CacheTimeout = *cacheTimeout
 	}
 
+	if *noUpdateAttr != false {
+		config.LDAP.NoUpdateAttr = true
+	}
+
 	var stats g2s.Statter
 	var statsErr error
 
@@ -208,7 +213,7 @@ func main() {
 
 	ldapCache, err := server.NewLDAPUserCache(ldapServer, stats, config.LDAP.UserAttr, config.LDAP.BaseDN,
 		config.LDAP.EnableLDAPRoles, config.LDAP.RoleAttribute, config.AWS.DefaultRole, config.LDAP.DefaultRoleAttr,
-		config.LDAP.GroupClassAttr, config.LDAP.PubKeysAttr, config.LDAP.RoleTimeoutAttr)
+		config.LDAP.GroupClassAttr, config.LDAP.PubKeysAttr, config.LDAP.RoleTimeoutAttr, config.LDAP.NoUpdateAttr)
 	if err != nil {
 		log.Errorf("Top-level error in LDAPUserCache layer: %s", err.Error())
 		os.Exit(1)

--- a/config/server.json
+++ b/config/server.json
@@ -12,7 +12,8 @@
     "defaultroleattr": "employeeType",
     "groupclassattr": "groupOfNames",
     "pubkeysattr": "sshPublicKey",
-    "roletimeoutattr": "timeoutAttribute"
+    "roletimeoutattr": "timeoutAttribute",
+    "noupdateattr": false
   },
   "aws": {
     "account":      "123456789010",

--- a/server/usercache_test.go
+++ b/server/usercache_test.go
@@ -147,7 +147,6 @@ func randomBytes(length int) []byte {
 	return buf
 }
 
-
 func TestLDAPUserCache(t *testing.T) {
 	Convey("Given an LDAP user cache connected to our server", t, func() {
 		// The SSH agent stuff was moved up here so that we can use it to
@@ -176,7 +175,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s := &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "")
+		lc, err := server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "", false)
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -250,7 +249,7 @@ func TestLDAPUserCache(t *testing.T) {
 		s = &StubLDAPServer{
 			Keys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "sshPublicKey", "", false)
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -273,7 +272,7 @@ func TestLDAPUserCache(t *testing.T) {
 			Keys:      []string{nonAuthorizedKey},
 			OtherKeys: []string{testAuthorizedKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "otherKeysAttribute", "")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "", "", "", "groupOfNames", "otherKeysAttribute", "", false)
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
@@ -302,11 +301,11 @@ func TestLDAPUserCache(t *testing.T) {
 		s = &StubLDAPServer{
 			Keys: []string{keyValue, testPublicKey},
 		}
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "timeoutAttribute")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "timeoutAttribute", false)
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
-		Convey ("If a role timeout attribute is set then it should be respected", func() {
+		Convey("If a role timeout attribute is set then it should be respected", func() {
 			Convey("Ensure LDAP user cache is updated with a non-default role timeout", func() {
 				groups := lc.Groups()
 				So(len(groups), ShouldEqual, 1)
@@ -323,11 +322,11 @@ func TestLDAPUserCache(t *testing.T) {
 			})
 		})
 
-		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "")
+		lc, err = server.NewLDAPUserCache(s, g2s.Noop(), "cn", "dc=testdn,dc=com", false, "roleAttribute", "", "", "groupOfNames", "sshPublicKey", "", false)
 		So(err, ShouldBeNil)
 		So(lc, ShouldNotBeNil)
 
-		Convey ("If no role timeout attribute is set, the default should be used.", func() {
+		Convey("If no role timeout attribute is set, the default should be used.", func() {
 			groups := lc.Groups()
 			So(len(groups), ShouldEqual, 1)
 			So(len(groups["testdn_0"].ARNs), ShouldEqual, 1)


### PR DESCRIPTION
This update introduces a configuration option and flag named NoUpdate to optimize the interaction between the cache and LDAP in environments where LDAP lookups are slow, such as with Okta LDAP implementations. Typically, when an SSH key is not found in the cache, the system would query LDAP to retrieve the missing information. However, in cases where the LDAP service is slow or inefficient, this process can cause significant delays, as experienced when users have multiple SSH keys. In some instances, these cache misses can result in LDAP lookups taking up to 40 seconds to resolve.

By enabling the NoUpdate flag, administrators can prevent the system from attempting an immediate LDAP lookup when a cache miss occurs. Instead, the system will rely on the periodic updates dictated by the `cachetimeout` parameter. This means that even if a key is not present in the cache at the moment of a lookup, the system will not block the operation by querying LDAP. Instead, it assumes that the cache will be updated at regular intervals according to the set `cachetimeout`, ensuring a smoother and faster user experience.

